### PR TITLE
PHP 7.4 upgrade hotfix: curly braces for array and string offset access

### DIFF
--- a/library/Zend/Barcode/Object/Code25.php
+++ b/library/Zend/Barcode/Object/Code25.php
@@ -134,7 +134,7 @@ class Zend_Barcode_Object_Code25 extends Zend_Barcode_Object_ObjectAbstract
         $checksum = 0;
 
         for ($i = strlen($text); $i > 0; $i --) {
-            $checksum += intval($text{$i - 1}) * $factor;
+            $checksum += intval($text[$i - 1]) * $factor;
             $factor    = 4 - $factor;
         }
 

--- a/library/Zend/Barcode/Object/Ean13.php
+++ b/library/Zend/Barcode/Object/Ean13.php
@@ -168,7 +168,7 @@ class Zend_Barcode_Object_Ean13 extends Zend_Barcode_Object_ObjectAbstract
         $checksum = 0;
 
         for ($i = strlen($text); $i > 0; $i --) {
-            $checksum += intval($text{$i - 1}) * $factor;
+            $checksum += intval($text[$i - 1]) * $factor;
             $factor    = 4 - $factor;
         }
 

--- a/library/Zend/Barcode/Object/Ean5.php
+++ b/library/Zend/Barcode/Object/Ean5.php
@@ -126,7 +126,7 @@ class Zend_Barcode_Object_Ean5 extends Zend_Barcode_Object_Ean13
         $checksum = 0;
 
         for ($i = 0 ; $i < $this->_barcodeLength; $i ++) {
-            $checksum += intval($text{$i}) * ($i % 2 ? 9 : 3);
+            $checksum += intval($text[$i]) * ($i % 2 ? 9 : 3);
         }
 
         return ($checksum % 10);

--- a/library/Zend/Barcode/Object/Ean8.php
+++ b/library/Zend/Barcode/Object/Ean8.php
@@ -125,7 +125,7 @@ class Zend_Barcode_Object_Ean8 extends Zend_Barcode_Object_Ean13
             $leftPosition = $this->getQuietZone() + (3 * $this->_barThinWidth) * $this->_factor;
             for ($i = 0; $i < $this->_barcodeLength; $i ++) {
                 $this->_addText(
-                    $text{$i},
+                    $text[$i],
                     $this->_fontSize * $this->_factor,
                     $this->_rotate(
                         $leftPosition,

--- a/library/Zend/Barcode/Object/Identcode.php
+++ b/library/Zend/Barcode/Object/Identcode.php
@@ -87,7 +87,7 @@ class Zend_Barcode_Object_Identcode extends Zend_Barcode_Object_Code25interleave
         $checksum = 0;
 
         for ($i = strlen($text); $i > 0; $i --) {
-            $checksum += intval($text{$i - 1}) * (($i % 2) ? 4 : 9);
+            $checksum += intval($text[$i - 1]) * (($i % 2) ? 4 : 9);
         }
 
         $checksum = (10 - ($checksum % 10)) % 10;

--- a/library/Zend/Barcode/Object/ObjectAbstract.php
+++ b/library/Zend/Barcode/Object/ObjectAbstract.php
@@ -1324,7 +1324,7 @@ abstract class Zend_Barcode_Object_ObjectAbstract
                 for ($i = 0; $i < $textLength; $i ++) {
                     $leftPosition = $this->getQuietZone() + $space * ($i + 0.5);
                     $this->_addText(
-                        $text{$i},
+                        $text[$i],
                         $this->_fontSize * $this->_factor,
                         $this->_rotate(
                             $leftPosition,

--- a/library/Zend/Barcode/Object/Upca.php
+++ b/library/Zend/Barcode/Object/Upca.php
@@ -142,7 +142,7 @@ class Zend_Barcode_Object_Upca extends Zend_Barcode_Object_Ean13
                     $fontSize *= 0.8;
                 }
                 $this->_addText(
-                    $text{$i},
+                    $text[$i],
                     $fontSize * $this->_factor,
                     $this->_rotate(
                         $leftPosition,

--- a/library/Zend/Barcode/Object/Upce.php
+++ b/library/Zend/Barcode/Object/Upce.php
@@ -86,8 +86,8 @@ class Zend_Barcode_Object_Upce extends Zend_Barcode_Object_Ean13
     public function getText()
     {
         $text = parent::getText();
-        if ($text{0} != 1) {
-            $text{0} = 0;
+        if ($text[0] != 1) {
+            $text[0] = 0;
         }
         return $text;
     }
@@ -160,7 +160,7 @@ class Zend_Barcode_Object_Upce extends Zend_Barcode_Object_Ean13
                     $fontSize *= 0.8;
                 }
                 $this->_addText(
-                    $text{$i},
+                    $text[$i],
                     $fontSize * $this->_factor,
                     $this->_rotate(
                         $leftPosition,
@@ -224,8 +224,8 @@ class Zend_Barcode_Object_Upce extends Zend_Barcode_Object_Ean13
     public function getChecksum($text)
     {
         $text = $this->_addLeadingZeros($text, true);
-        if ($text{0} != 1) {
-            $text{0} = 0;
+        if ($text[0] != 1) {
+            $text[0] = 0;
         }
         return parent::getChecksum($text);
     }

--- a/library/Zend/Db/Statement.php
+++ b/library/Zend/Db/Statement.php
@@ -191,7 +191,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         if (!empty($q)) {
             $escapeChar = preg_quote($escapeChar);
             // this segfaults only after 65,000 characters instead of 9,000
-            $sql = preg_replace("/$q([^$q{$escapeChar}]*|($qe)*)*$q/s", '', $sql);
+            $sql = preg_replace("/$q([^$q[$escapeChar]]*|($qe)*)*$q/s", '', $sql);
         }
         
         // get a version of the SQL statement with all quoted

--- a/library/Zend/Json/Encoder.php
+++ b/library/Zend/Json/Encoder.php
@@ -560,17 +560,17 @@ class Zend_Json_Encoder
             case 2:
                 // return a UTF-16 character from a 2-byte UTF-8 char
                 // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                return chr(0x07 & (ord($utf8{0}) >> 2))
-                     . chr((0xC0 & (ord($utf8{0}) << 6))
-                         | (0x3F & ord($utf8{1})));
+                return chr(0x07 & (ord($utf8[0]) >> 2))
+                     . chr((0xC0 & (ord($utf8[0]) << 6))
+                         | (0x3F & ord($utf8[1])));
 
             case 3:
                 // return a UTF-16 character from a 3-byte UTF-8 char
                 // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                return chr((0xF0 & (ord($utf8{0}) << 4))
-                         | (0x0F & (ord($utf8{1}) >> 2)))
-                     . chr((0xC0 & (ord($utf8{1}) << 6))
-                         | (0x7F & ord($utf8{2})));
+                return chr((0xF0 & (ord($utf8[0]) << 4))
+                         | (0x0F & (ord($utf8[1]) >> 2)))
+                     . chr((0xC0 & (ord($utf8[1]) << 6))
+                         | (0x7F & ord($utf8[2])));
         }
 
         // ignoring UTF-32 for now, sorry

--- a/library/Zend/Validate/Isbn.php
+++ b/library/Zend/Validate/Isbn.php
@@ -185,9 +185,9 @@ class Zend_Validate_Isbn extends Zend_Validate_Abstract
                 $sum    = 0;
                 for ($i = 0; $i < 12; $i++) {
                     if ($i % 2 == 0) {
-                        $sum += $isbn13{$i};
+                        $sum += $isbn13[$i];
                     } else {
-                        $sum += 3 * $isbn13{$i};
+                        $sum += 3 * $isbn13[$i];
                     }
                 }
                 // checksum

--- a/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -253,10 +253,10 @@ class Zend_View_Helper_Navigation_Sitemap
     {
         $href = $page->getHref();
 
-        if (!isset($href{0})) {
+        if (!isset($href[0])) {
             // no href
             return '';
-        } elseif ($href{0} == '/') {
+        } elseif ($href[0] == '/') {
             // href is relative to root; use serverUrl helper
             $url = $this->getServerUrl() . $href;
         } elseif (preg_match('/^[a-z]+:/im', (string) $href)) {


### PR DESCRIPTION
https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace

> The array and string offset access syntax using curly braces is deprecated. Use _$var[$idx]_ instead of _$var{$idx}_.
