### PR TITLE
PHPUnit 9 upgrade, drop PHP 7.1-7.2 support

### DIFF
--- a/DEVELOPMENT_README.md
+++ b/DEVELOPMENT_README.md
@@ -39,8 +39,8 @@ and specify your UID:GID there:
 
 ### 5. Enter container interactive shell
 
-    docker-compose run --rm php71 bash # for PHP 7.1
-    docker-compose run --rm php72 bash # for PHP 7.2
+    docker-compose run --rm php71 bash # for PHP 7.3
+    docker-compose run --rm php72 bash # for PHP 7.4
 
 > PHP 7.0 is not supported
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=7.1 <7.5"
+        "php": ">=7.3 <7.5"
     },
     "replace": {
         "zendframework/zendframework1": "1.12.20"
@@ -31,8 +31,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.5.15",
-        "phpunit/dbunit": "4.0.*"
+        "phpunit/phpunit": "~9.0.1",
+        "kornrunner/dbunit": "^5.0"
     },
     "archive": {
         "exclude": ["/demos", "/documentation", "/tests"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d70fca799527226703883e89dab4338b",
+    "content-hash": "daed9cc373cad2d18d36b1160f43ec39",
     "packages": [],
     "packages-dev": [
         {
@@ -62,6 +62,61 @@
                 "instantiate"
             ],
             "time": "2019-10-21T16:45:58+00:00"
+        },
+        {
+            "name": "kornrunner/dbunit",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kornrunner/dbunit.git",
+                "reference": "d597de2293ec7c149b7004ccb3c727ecbb244541"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kornrunner/dbunit/zipball/d597de2293ec7c149b7004ccb3c727ecbb244541",
+                "reference": "d597de2293ec7c149b7004ccb3c727ecbb244541",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pdo": "*",
+                "ext-simplexml": "*",
+                "php": "^7.2",
+                "phpunit/phpunit": "^8.2 || ^9.0",
+                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+            },
+            "replace": {
+                "phpunit/dbunit": "self.version"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHPUnit extension for database interaction testing",
+            "homepage": "https://github.com/sebastianbergmann/dbunit/",
+            "keywords": [
+                "database",
+                "testing",
+                "xunit"
+            ],
+            "time": "2019-12-19T06:26:43+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -429,94 +484,42 @@
             "time": "2020-01-20T15:57:02+00:00"
         },
         {
-            "name": "phpunit/dbunit",
-            "version": "4.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/dbunit.git",
-                "reference": "e77b469c3962b5a563f09a2a989f1c9bd38b8615"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/dbunit/zipball/e77b469c3962b5a563f09a2a989f1c9bd38b8615",
-                "reference": "e77b469c3962b5a563f09a2a989f1c9bd38b8615",
-                "shasum": ""
-            },
-            "require": {
-                "ext-pdo": "*",
-                "ext-simplexml": "*",
-                "php": "^7.1",
-                "phpunit/phpunit": "^7.0",
-                "symfony/yaml": "^3.0 || ^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHPUnit extension for database interaction testing",
-            "homepage": "https://github.com/sebastianbergmann/dbunit/",
-            "keywords": [
-                "database",
-                "testing",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2018-02-07T06:47:59+00:00"
-        },
-        {
             "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "version": "8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/31e94ccc084025d6abee0585df533eb3a792b96a",
+                "reference": "31e94ccc084025d6abee0585df533eb3a792b96a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "php": "^7.3",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-token-stream": "^4.0",
+                "sebastian/code-unit-reverse-lookup": "^2.0",
+                "sebastian/environment": "^5.0",
+                "sebastian/version": "^3.0",
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "8.0-dev"
                 }
             },
             "autoload": {
@@ -542,32 +545,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31T16:06:48+00:00"
+            "time": "2020-02-19T13:41:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/354d4a5faa7449a377a18b94a2026ca3415e3d7a",
+                "reference": "354d4a5faa7449a377a18b94a2026ca3415e3d7a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -592,26 +595,84 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-09-13T20:33:42+00:00"
+            "time": "2020-02-07T06:05:22+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/7579d5a1ba7f3ac11c80004d205877911315ae7a",
+                "reference": "7579d5a1ba7f3ac11c80004d205877911315ae7a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "time": "2020-02-07T06:06:11+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "reference": "526dc996cc0ebdfa428cd2dfccd79b7b53fee346",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -633,32 +694,32 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2020-02-01T07:43:44+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+                "reference": "4118013a4d0f97356eae8e7fb2f6c6472575d1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/4118013a4d0f97356eae8e7fb2f6c6472575d1df",
+                "reference": "4118013a4d0f97356eae8e7fb2f6c6472575d1df",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -682,33 +743,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-06-07T04:22:29+00:00"
+            "time": "2020-02-07T06:08:11+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/b2560a0c33f7710e4d7f8780964193e8e8f8effe",
+                "reference": "b2560a0c33f7710e4d7f8780964193e8e8f8effe",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -731,57 +792,56 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2019-09-17T06:23:10+00:00"
+            "time": "2020-02-07T06:19:00+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.20",
+            "version": "9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+                "reference": "68d7e5b17a6b9461e17c00446caa409863154f76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/68d7e5b17a6b9461e17c00446caa409863154f76",
+                "reference": "68d7e5b17a6b9461e17c00446caa409863154f76",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.1",
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.7",
-                "phar-io/manifest": "^1.0.2",
-                "phar-io/version": "^2.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
-                "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.3",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^8.0",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/php-invoker": "^3.0",
+                "phpunit/php-text-template": "^2.0",
+                "phpunit/php-timer": "^3.0",
+                "sebastian/comparator": "^4.0",
+                "sebastian/diff": "^4.0",
+                "sebastian/environment": "^5.0",
+                "sebastian/exporter": "^4.0",
+                "sebastian/global-state": "^4.0",
+                "sebastian/object-enumerator": "^4.0",
+                "sebastian/resource-operations": "^3.0",
+                "sebastian/type": "^2.0",
+                "sebastian/version": "^3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-soap": "*",
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -789,12 +849,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "9.0-dev"
                 }
             },
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -815,32 +878,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-08T08:45:45+00:00"
+            "time": "2020-02-13T07:30:12+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5b5dbe0044085ac41df47e79d34911a15b96d82e",
+                "reference": "5b5dbe0044085ac41df47e79d34911a15b96d82e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -860,34 +923,34 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "time": "2020-02-07T06:20:13+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/85b3435da967696ed618ff745f32be3ff4a2b8e8",
+                "reference": "85b3435da967696ed618ff745f32be3ff4a2b8e8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": "^7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -900,6 +963,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -911,10 +978,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -924,33 +987,33 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-07-12T15:12:46+00:00"
+            "time": "2020-02-07T06:08:51+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c0c26c9188b538bfa985ae10c9f05d278f12060d",
+                "reference": "c0c26c9188b538bfa985ae10c9f05d278f12060d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.0",
+                "symfony/process": "^4 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -964,12 +1027,12 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
@@ -980,27 +1043,27 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2019-02-04T06:01:07+00:00"
+            "time": "2020-02-07T06:09:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.3",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
+                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
+                "reference": "9bffdefa7810031a165ddd6275da6a2c1f6f2dfb",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1008,7 +1071,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1033,34 +1096,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-11-20T08:46:58+00:00"
+            "time": "2020-02-19T13:40:20+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+                "reference": "80c26562e964016538f832f305b2286e1ec29566"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/80c26562e964016538f832f305b2286e1ec29566",
+                "reference": "80c26562e964016538f832f305b2286e1ec29566",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": "^7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1100,27 +1163,30 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-09-14T09:02:43+00:00"
+            "time": "2020-02-07T06:10:52+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
+                "reference": "bdb1e7c79e592b8c82cb1699be3c8743119b8a72",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1128,7 +1194,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1151,34 +1217,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "time": "2020-02-07T06:11:37+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "reference": "e67516b175550abad905dc952f43285957ef4363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67516b175550abad905dc952f43285957ef4363",
+                "reference": "e67516b175550abad905dc952f43285957ef4363",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": "^7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1198,122 +1264,27 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "time": "2020-02-07T06:12:23+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
+                "reference": "f4fd0835cabb0d4a6546d9fe291e5740037aa1e7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
@@ -1336,31 +1307,175 @@
                     "email": "sebastian@phpunit.de"
                 }
             ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-10-04T04:07:39+00:00"
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2020-02-07T06:19:40+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "2.0.1",
+            "name": "sebastian/recursion-context",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cdd86616411fc3062368b720b0425de10bd3d579",
+                "reference": "cdd86616411fc3062368b720b0425de10bd3d579",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2020-02-07T06:18:20+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
+                "reference": "8c98bf0dfa1f9256d0468b9803a1e1df31b6fa98",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2020-02-07T06:13:02+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/9e8f42f740afdea51f5f4e8cec2035580e797ee1",
+                "reference": "9e8f42f740afdea51f5f4e8cec2035580e797ee1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2020-02-07T06:13:43+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/0411bde656dce64202b39c2f4473993a9081d39e",
+                "reference": "0411bde656dce64202b39c2f4473993a9081d39e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1381,7 +1496,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "time": "2020-01-21T06:36:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1443,27 +1558,27 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.4.4",
+            "version": "v5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "cd014e425b3668220adb865f53bff64b3ad21767"
+                "reference": "69b44e3b8f90949aee2eb3aa9b86ceeb01cbf62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/cd014e425b3668220adb865f53bff64b3ad21767",
-                "reference": "cd014e425b3668220adb865f53bff64b3ad21767",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/69b44e3b8f90949aee2eb3aa9b86ceeb01cbf62a",
+                "reference": "69b44e3b8f90949aee2eb3aa9b86ceeb01cbf62a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": "^7.2.5",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "symfony/console": "<3.4"
+                "symfony/console": "<4.4"
             },
             "require-dev": {
-                "symfony/console": "^3.4|^4.0|^5.0"
+                "symfony/console": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -1471,7 +1586,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1498,7 +1613,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-21T11:12:16+00:00"
+            "time": "2020-01-21T11:12:28+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1595,7 +1710,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1 <7.5"
+        "php": ">=7.3 <7.5"
     },
     "platform-dev": []
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,6 @@
 version: "3"
 
 services:
-  php71:
-    build:
-      context: ./docker/php
-      args:
-        PHP_VERSION: 7.1
-        HOST_USER: 1000:1000
-    depends_on:
-      - mysql
-      - postgres
-    volumes:
-      - .:/www-data/zf1
-      - composer-cache:/var/www/.composer/cache/
-    working_dir: /www-data/zf1
-  php72:
-    build:
-      context: ./docker/php
-      args:
-        PHP_VERSION: 7.2
-        HOST_USER: 1000:1000
-    depends_on:
-      - mysql
-      - postgres
-    volumes:
-      - .:/www-data/zf1
-      - composer-cache:/var/www/.composer/cache/
-    working_dir: /www-data/zf1
   php73:
     build:
       context: ./docker/php

--- a/library/Zend/Loader/StandardAutoloader.php
+++ b/library/Zend/Loader/StandardAutoloader.php
@@ -218,6 +218,14 @@ class Zend_Loader_StandardAutoloader implements Zend_Loader_SplAutoloader
     }
 
     /**
+     * @return array
+     */
+    public function getPrefixes()
+    {
+        return $this->prefixes;
+    }
+
+    /**
      * Defined by Autoloadable; autoload a class
      *
      * @param  string $class

--- a/library/Zend/Test/PHPUnit/Constraint/DomQuery.php
+++ b/library/Zend/Test/PHPUnit/Constraint/DomQuery.php
@@ -147,7 +147,7 @@ class Zend_Test_PHPUnit_Constraint_DomQuery extends Constraint
      *     public function evaluate($other, $description = '', $returnResult = FALSE)
      * We use the new interface for PHP-strict checking, but emulate the old one
      */
-    public function evaluate($content, $assertType = '', $match = FALSE)
+    public function evaluate($content, $assertType = '', $match = FALSE): ?bool
     {
         if (strstr($assertType, 'Not')) {
             $this->setNegate(true);

--- a/library/Zend/Test/PHPUnit/Constraint/Exception.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Exception.php
@@ -20,18 +20,18 @@
  * @version    $Id$
  */
 
-use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\AssertionFailedError;
 
 /**
  * Zend_Test_PHPUnit_Constraint_Exception
  *
- * @uses       ExpectationFailedException
+ * @uses       AssertionFailedError
  * @category   Zend
  * @package    Zend_Test
  * @subpackage PHPUnit
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Test_PHPUnit_Constraint_Exception extends ExpectationFailedException
+class Zend_Test_PHPUnit_Constraint_Exception extends AssertionFailedError
 {
 }

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect.php
@@ -109,7 +109,7 @@ class Zend_Test_PHPUnit_Constraint_Redirect extends Constraint
      *     public function evaluate($other, $description = '', $returnResult = FALSE)
      * We use the new interface for PHP-strict checking, but emulate the old one
      */
-    public function evaluate($other, $assertType = null, $variable = FALSE)
+    public function evaluate($other, $assertType = null, $variable = FALSE): ?bool
     {
         if (!$other instanceof Zend_Controller_Response_Abstract) {
             require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';

--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -122,7 +122,7 @@ abstract class Zend_Test_PHPUnit_ControllerTestCase extends TestCase
      *
      * Calls {@link bootstrap()} by default
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->bootstrap();
     }

--- a/tests/Zend/AllTests/StreamWrapper/PhpInput.php
+++ b/tests/Zend/AllTests/StreamWrapper/PhpInput.php
@@ -26,7 +26,7 @@
  * <code>
  * class ...
  * {
- *     public function setUp()
+ *     public function setUp(): void
  *     {
  *         Zend_AllTests_StreamWrapper_PhpInput::mockInput('expected string');
  *     }
@@ -37,7 +37,7 @@
  *         $this->assertSame('php://input', Zend_AllTests_StreamWrapper_PhpInput::getCurrentPath());
  *     }
  *
- *     public function tearDown()
+ *     public function tearDown(): void
  *     {
  *         Zend_AllTests_StreamWrapper_PhpInput::restoreDefault();
  *     }

--- a/tests/Zend/Application/ApplicationTest.php
+++ b/tests/Zend/Application/ApplicationTest.php
@@ -36,7 +36,7 @@ require_once 'Zend/Application.php';
  */
 class Zend_Application_ApplicationTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -57,7 +57,7 @@ class Zend_Application_ApplicationTest extends \PHPUnit\Framework\TestCase
         $this->iniOptions = array();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();
@@ -176,7 +176,7 @@ class Zend_Application_ApplicationTest extends \PHPUnit\Framework\TestCase
             ),
         ));
         $test = get_include_path();
-        $this->assertContains($expected, $test);
+        $this->assertStringContainsString($expected, $test);
     }
 
     public function testPassingPhpSettingsSetsIniValues()

--- a/tests/Zend/Application/Bootstrap/BootstrapAbstractTest.php
+++ b/tests/Zend/Application/Bootstrap/BootstrapAbstractTest.php
@@ -60,7 +60,7 @@ require_once 'Zend/Application/Bootstrap/Bootstrap.php';
  */
 class Zend_Application_Bootstrap_BootstrapAbstractTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -77,7 +77,7 @@ class Zend_Application_Bootstrap_BootstrapAbstractTest extends \PHPUnit\Framewor
         $this->error = false;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Bootstrap/BootstrapTest.php
+++ b/tests/Zend/Application/Bootstrap/BootstrapTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Bootstrap_BootstrapTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -56,7 +56,7 @@ class Zend_Application_Bootstrap_BootstrapTest extends \PHPUnit\Framework\TestCa
         $this->resetFrontController();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Module/AutoloaderTest.php
+++ b/tests/Zend/Application/Module/AutoloaderTest.php
@@ -48,7 +48,7 @@ require_once 'Zend/Config.php';
  */
 class Zend_Application_Module_AutoloaderTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -73,7 +73,7 @@ class Zend_Application_Module_AutoloaderTest extends \PHPUnit\Framework\TestCase
         ));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();
@@ -100,7 +100,7 @@ class Zend_Application_Module_AutoloaderTest extends \PHPUnit\Framework\TestCase
     public function testDbTableResourceTypeShouldPointToModelsDbTableSubdirectory()
     {
         $resources = $this->loader->getResourceTypes();
-        $this->assertContains('models/DbTable', $resources['dbtable']['path']);
+        $this->assertStringContainsString('models/DbTable', $resources['dbtable']['path']);
     }
 
     public function testFormResourceTypeShouldBeLoadedByDefault()
@@ -111,7 +111,7 @@ class Zend_Application_Module_AutoloaderTest extends \PHPUnit\Framework\TestCase
     public function testFormResourceTypeShouldPointToFormsSubdirectory()
     {
         $resources = $this->loader->getResourceTypes();
-        $this->assertContains('forms', $resources['form']['path']);
+        $this->assertStringContainsString('forms', $resources['form']['path']);
     }
 
     public function testModelResourceTypeShouldBeLoadedByDefault()
@@ -122,7 +122,7 @@ class Zend_Application_Module_AutoloaderTest extends \PHPUnit\Framework\TestCase
     public function testModelResourceTypeShouldPointToModelsSubdirectory()
     {
         $resources = $this->loader->getResourceTypes();
-        $this->assertContains('models', $resources['model']['path']);
+        $this->assertStringContainsString('models', $resources['model']['path']);
     }
 
     public function testPluginResourceTypeShouldBeLoadedByDefault()
@@ -133,7 +133,7 @@ class Zend_Application_Module_AutoloaderTest extends \PHPUnit\Framework\TestCase
     public function testPluginResourceTypeShouldPointToPluginsSubdirectory()
     {
         $resources = $this->loader->getResourceTypes();
-        $this->assertContains('plugins', $resources['plugin']['path']);
+        $this->assertStringContainsString('plugins', $resources['plugin']['path']);
     }
 
     public function testServiceResourceTypeShouldBeLoadedByDefault()
@@ -144,7 +144,7 @@ class Zend_Application_Module_AutoloaderTest extends \PHPUnit\Framework\TestCase
     public function testServiceResourceTypeShouldPointToServicesSubdirectory()
     {
         $resources = $this->loader->getResourceTypes();
-        $this->assertContains('services', $resources['service']['path']);
+        $this->assertStringContainsString('services', $resources['service']['path']);
     }
 
     public function testViewHelperResourceTypeShouldBeLoadedByDefault()
@@ -155,7 +155,7 @@ class Zend_Application_Module_AutoloaderTest extends \PHPUnit\Framework\TestCase
     public function testViewHelperResourceTypeShouldPointToViewHelperSubdirectory()
     {
         $resources = $this->loader->getResourceTypes();
-        $this->assertContains('views/helpers', $resources['viewhelper']['path']);
+        $this->assertStringContainsString('views/helpers', $resources['viewhelper']['path']);
     }
 
     public function testViewFilterResourceTypeShouldBeLoadedByDefault()
@@ -166,7 +166,7 @@ class Zend_Application_Module_AutoloaderTest extends \PHPUnit\Framework\TestCase
     public function testViewFilterResourceTypeShouldPointToViewFilterSubdirectory()
     {
         $resources = $this->loader->getResourceTypes();
-        $this->assertContains('views/filters', $resources['viewfilter']['path']);
+        $this->assertStringContainsString('views/filters', $resources['viewfilter']['path']);
     }
 
     public function testDefaultResourceShouldBeModel()

--- a/tests/Zend/Application/Module/BootstrapTest.php
+++ b/tests/Zend/Application/Module/BootstrapTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Module_BootstrapTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -53,7 +53,7 @@ class Zend_Application_Module_BootstrapTest extends \PHPUnit\Framework\TestCase
         Zend_Controller_Front::getInstance()->resetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Resource/CacheManagerTest.php
+++ b/tests/Zend/Application/Resource/CacheManagerTest.php
@@ -55,7 +55,7 @@ require_once 'Zend/Cache/Core.php';
  */
 class Zend_Application_Resource_CacheManagerTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -74,7 +74,7 @@ class Zend_Application_Resource_CacheManagerTest extends \PHPUnit\Framework\Test
         $this->bootstrap = new ZfAppBootstrap($this->application);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();
@@ -229,7 +229,7 @@ class Zend_Application_Resource_CacheManagerTest extends \PHPUnit\Framework\Test
 
         $this->assertTrue(is_array($event));
         $this->assertTrue(array_key_exists('message', $event));
-        $this->assertContains('Zend_Cache_Backend_Static', $event['message']);
+        $this->assertStringContainsString('Zend_Cache_Backend_Static', $event['message']);
     }
 }
 

--- a/tests/Zend/Application/Resource/DbTest.php
+++ b/tests/Zend/Application/Resource/DbTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Resource_DbTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -54,7 +54,7 @@ class Zend_Application_Resource_DbTest extends \PHPUnit\Framework\TestCase
         $this->bootstrap = new ZfAppBootstrap($this->application);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
     	Zend_Db_Table::setDefaultMetadataCache();
 

--- a/tests/Zend/Application/Resource/FrontcontrollerTest.php
+++ b/tests/Zend/Application/Resource/FrontcontrollerTest.php
@@ -40,7 +40,7 @@ require_once 'Zend/Controller/Front.php';
  */
 class Zend_Application_Resource_FrontcontrollerTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -59,7 +59,7 @@ class Zend_Application_Resource_FrontcontrollerTest extends \PHPUnit\Framework\T
         $this->bootstrap = new ZfAppBootstrap($this->application);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Resource/LayoutTest.php
+++ b/tests/Zend/Application/Resource/LayoutTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Resource_LayoutTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -55,7 +55,7 @@ class Zend_Application_Resource_LayoutTest extends \PHPUnit\Framework\TestCase
         Zend_Controller_Front::getInstance()->resetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Resource/LocaleTest.php
+++ b/tests/Zend/Application/Resource/LocaleTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Resource_LocaleTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -55,7 +55,7 @@ class Zend_Application_Resource_LocaleTest extends \PHPUnit\Framework\TestCase
         Zend_Registry::_unsetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Resource/LogTest.php
+++ b/tests/Zend/Application/Resource/LogTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Resource_LogTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -53,7 +53,7 @@ class Zend_Application_Resource_LogTest extends \PHPUnit\Framework\TestCase
         Zend_Controller_Front::getInstance()->resetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();
@@ -110,7 +110,7 @@ class Zend_Application_Resource_LogTest extends \PHPUnit\Framework\TestCase
 
         $log->log($message = 'logged-message', Zend_Log::INFO);
         rewind($stream);
-        $this->assertContains($message, stream_get_contents($stream));
+        $this->assertStringContainsString($message, stream_get_contents($stream));
     }
 
     /**

--- a/tests/Zend/Application/Resource/MailTest.php
+++ b/tests/Zend/Application/Resource/MailTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Resource_MailTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -53,7 +53,7 @@ class Zend_Application_Resource_MailTest extends \PHPUnit\Framework\TestCase
         Zend_Controller_Front::getInstance()->resetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Mail::clearDefaultTransport();
 

--- a/tests/Zend/Application/Resource/ModulesTest.php
+++ b/tests/Zend/Application/Resource/ModulesTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Resource_ModulesTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -57,7 +57,7 @@ class Zend_Application_Resource_ModulesTest extends \PHPUnit\Framework\TestCase
         $this->front->resetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Resource/MultidbTest.php
+++ b/tests/Zend/Application/Resource/MultidbTest.php
@@ -46,7 +46,7 @@ class Zend_Application_Resource_MultidbTest extends \PHPUnit\Framework\TestCase
     protected $_dbOptions = array('db1' => array('adapter' => 'pdo_mysql','dbname' => 'db1','password' => 'XXXX','username' => 'webuser'),
                                 'db2' => array('adapter' => 'pdo_pgsql', 'dbname' => 'db2', 'password' => 'notthatpublic', 'username' => 'dba'));
 
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -64,7 +64,7 @@ class Zend_Application_Resource_MultidbTest extends \PHPUnit\Framework\TestCase
         Zend_Controller_Front::getInstance()->resetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Db_Table::setDefaultAdapter(null);
         Zend_Db_Table::setDefaultMetadataCache();

--- a/tests/Zend/Application/Resource/NavigationTest.php
+++ b/tests/Zend/Application/Resource/NavigationTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Resource_NavigationTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -55,7 +55,7 @@ class Zend_Application_Resource_NavigationTest extends \PHPUnit\Framework\TestCa
         Zend_Registry::_unsetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Navigation_Page::setDefaultPageType();
 

--- a/tests/Zend/Application/Resource/ResourceAbstractTest.php
+++ b/tests/Zend/Application/Resource/ResourceAbstractTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Resource_ResourceAbstractTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -54,7 +54,7 @@ class Zend_Application_Resource_ResourceAbstractTest extends \PHPUnit\Framework\
         $this->bootstrap = new ZfAppBootstrap($this->application);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Resource/RouterTest.php
+++ b/tests/Zend/Application/Resource/RouterTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Loader/Autoloader.php';
  */
 class Zend_Application_Resource_RouterTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -53,7 +53,7 @@ class Zend_Application_Resource_RouterTest extends \PHPUnit\Framework\TestCase
         Zend_Controller_Front::getInstance()->resetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Resource/SessionTest.php
+++ b/tests/Zend/Application/Resource/SessionTest.php
@@ -37,7 +37,7 @@ class Zend_Application_Resource_SessionTest extends \PHPUnit\Framework\TestCase
 {
     public $resource;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->resource = new Zend_Application_Resource_Session();
     }

--- a/tests/Zend/Application/Resource/TranslateTest.php
+++ b/tests/Zend/Application/Resource/TranslateTest.php
@@ -61,7 +61,7 @@ class Zend_Application_Resource_TranslateTest extends \PHPUnit\Framework\TestCas
      */
     protected $bootstrap;
 
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -81,7 +81,7 @@ class Zend_Application_Resource_TranslateTest extends \PHPUnit\Framework\TestCas
         Zend_Registry::_unsetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Application/Resource/ViewTest.php
+++ b/tests/Zend/Application/Resource/ViewTest.php
@@ -37,7 +37,7 @@ require_once 'Zend/Application/Resource/View.php';
  */
 class Zend_Application_Resource_ViewTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -58,7 +58,7 @@ class Zend_Application_Resource_ViewTest extends \PHPUnit\Framework\TestCase
         Zend_Controller_Action_HelperBroker::resetHelpers();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Controller/Action/Helper/ActionStackTest.php
+++ b/tests/Zend/Controller/Action/Helper/ActionStackTest.php
@@ -55,7 +55,7 @@ class Zend_Controller_Action_Helper_ActionStackTest extends \PHPUnit\Framework\T
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->front = Zend_Controller_Front::getInstance();
         $this->front->resetInstance();
@@ -70,7 +70,7 @@ class Zend_Controller_Action_Helper_ActionStackTest extends \PHPUnit\Framework\T
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 

--- a/tests/Zend/Controller/Action/Helper/AjaxContextTest.php
+++ b/tests/Zend/Controller/Action/Helper/AjaxContextTest.php
@@ -53,7 +53,7 @@ class Zend_Controller_Action_Helper_AjaxContextTest extends \PHPUnit\Framework\T
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         if (isset($_SERVER['HTTP_X_REQUESTED_WITH'])) {
             unset($_SERVER['HTTP_X_REQUESTED_WITH']);
@@ -93,7 +93,7 @@ class Zend_Controller_Action_Helper_AjaxContextTest extends \PHPUnit\Framework\T
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if (isset($_SERVER['HTTP_X_REQUESTED_WITH'])) {
             unset($_SERVER['HTTP_X_REQUESTED_WITH']);

--- a/tests/Zend/Controller/Action/Helper/AutoCompleteTest.php
+++ b/tests/Zend/Controller/Action/Helper/AutoCompleteTest.php
@@ -51,7 +51,7 @@ class Zend_Controller_Action_Helper_AutoCompleteTest extends \PHPUnit\Framework\
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Controller_Action_Helper_AutoCompleteTest_LayoutOverride::resetMvcInstance();
         Zend_Controller_Action_HelperBroker::resetHelpers();
@@ -73,7 +73,7 @@ class Zend_Controller_Action_Helper_AutoCompleteTest extends \PHPUnit\Framework\
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
@@ -94,7 +94,7 @@ class Zend_Controller_Action_Helper_AutoCompleteTest extends \PHPUnit\Framework\
             $encoded = $scriptaculous->encodeJson($data);
             $this->fail('Objects should be considered invalid');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('Invalid data', $e->getMessage());
+            $this->assertStringContainsString('Invalid data', $e->getMessage());
         }
     }
 
@@ -104,11 +104,11 @@ class Zend_Controller_Action_Helper_AutoCompleteTest extends \PHPUnit\Framework\
         $scriptaculous->suppressExit = true;
         $data = array('foo', 'bar', 'baz');
         $formatted = $scriptaculous->direct($data);
-        $this->assertContains('<ul>', $formatted);
+        $this->assertStringContainsString('<ul>', $formatted);
         foreach ($data as $value) {
-            $this->assertContains('<li>' . $value . '</li>', $formatted);
+            $this->assertStringContainsString('<li>' . $value . '</li>', $formatted);
         }
-        $this->assertContains('</ul>', $formatted);
+        $this->assertStringContainsString('</ul>', $formatted);
     }
 
     public function testScriptaculousHelperSendsResponseByDefault()

--- a/tests/Zend/Controller/Action/Helper/CacheTest.php
+++ b/tests/Zend/Controller/Action/Helper/CacheTest.php
@@ -17,7 +17,7 @@ class Zend_Controller_Action_Helper_CacheTest extends \PHPUnit\Framework\TestCas
 
     protected $_requestUriOld;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_requestUriOld =
             isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : null;
@@ -31,7 +31,7 @@ class Zend_Controller_Action_Helper_CacheTest extends \PHPUnit\Framework\TestCas
         $this->front->setRequest($this->request);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $_SERVER['REQUEST_URI'] = $this->_requestUriOld;
     }

--- a/tests/Zend/Controller/Action/Helper/ContextSwitchTest.php
+++ b/tests/Zend/Controller/Action/Helper/ContextSwitchTest.php
@@ -53,7 +53,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Controller_Action_Helper_ContextSwitchTest_LayoutOverride::resetMvcInstance();
         Zend_Controller_Action_HelperBroker::resetHelpers();
@@ -93,7 +93,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
@@ -106,21 +106,21 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
     public function testSetSuffixModifiesContextSuffix()
     {
         $this->helper->setSuffix('xml', 'foobar');
-        $this->assertContains('foobar', $this->helper->getSuffix('xml'));
+        $this->assertStringContainsString('foobar', $this->helper->getSuffix('xml'));
     }
 
     public function testSetSuffixPrependsToViewRendererSuffixByDefault()
     {
         $this->helper->setSuffix('xml', 'foobar');
         $expected = 'foobar.' . $this->viewRenderer->getViewSuffix();
-        $this->assertContains($expected, $this->helper->getSuffix('xml'));
+        $this->assertStringContainsString($expected, $this->helper->getSuffix('xml'));
     }
 
     public function testCanSetSuffixWithoutViewRendererSuffix()
     {
         $this->helper->setSuffix('xml', 'foobar', false);
         $expected = 'foobar';
-        $this->assertContains($expected, $this->helper->getSuffix('xml'));
+        $this->assertStringContainsString($expected, $this->helper->getSuffix('xml'));
     }
 
     public function testSuffixAccessorsThrowExceptionOnInvalidContextType()
@@ -129,14 +129,14 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
             $this->helper->setSuffix('foobar', 'foobar');
             $this->fail('setSuffix() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('Cannot set suffix', $e->getMessage());
+            $this->assertStringContainsString('Cannot set suffix', $e->getMessage());
         }
 
         try {
             $this->helper->getSuffix('foobar');
             $this->fail('getSuffix() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('Cannot retrieve suffix', $e->getMessage());
+            $this->assertStringContainsString('Cannot retrieve suffix', $e->getMessage());
         }
     }
 
@@ -171,7 +171,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
             $this->helper->addHeader('xml', 'Content-Type', 'application/xml');
             $this->fail('addHeader() should raise exception for existing headers');
         } catch (Zend_Controller_Exception $e) {
-            $this->assertContains('already exists', $e->getMessage());
+            $this->assertStringContainsString('already exists', $e->getMessage());
         }
     }
 
@@ -214,56 +214,56 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
             $this->helper->addHeader('foobar', 'foobar', 'baz');
             $this->fail('addHeader() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         try {
             $this->helper->setHeader('foobar', 'foobar', 'baz');
             $this->fail('setHeader() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         try {
             $this->helper->getHeader('foobar', 'Content-Type');
             $this->fail('getHeader() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         try {
             $this->helper->getHeaders('foobar');
             $this->fail('getHeaders() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         try {
             $this->helper->addHeaders('foobar', array('X-Foo' => 'Bar'));
             $this->fail('addHeaders() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         try {
             $this->helper->setHeaders('foobar', array('X-Foo' => 'Bar'));
             $this->fail('setHeaders() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         try {
             $this->helper->removeHeader('foobar', 'X-Foo');
             $this->fail('removeHeader() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         try {
             $this->helper->clearHeaders('foobar');
             $this->fail('clearHeaders() should throw exception with invalid context type');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
     }
 
@@ -314,7 +314,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
         $this->assertTrue(isset($context['headers']));
         $this->assertTrue(isset($context['callbacks']));
 
-        $this->assertContains('foo.bar', $context['suffix']);
+        $this->assertStringContainsString('foo.bar', $context['suffix']);
         $this->assertEquals('application/x-foobar', $context['headers']['Content-Type']);
         $this->assertEquals('Bar', $context['headers']['X-Foo']);
     }
@@ -325,7 +325,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
             $this->helper->addContext('xml', array());
             $this->fail('Shold not be able to add context if already exists');
         } catch (Zend_Controller_Exception $e) {
-            $this->assertContains('exists', $e->getMessage());
+            $this->assertStringContainsString('exists', $e->getMessage());
         }
     }
 
@@ -375,9 +375,9 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
         $this->assertTrue($this->helper->hasContext('barbaz'));
         $this->assertEquals('xml', $this->helper->getSuffix('xml'));
         $this->assertNotEquals('foo.bar', $this->helper->getSuffix('foobar'));
-        $this->assertContains('foo.bar', $this->helper->getSuffix('foobar'));
+        $this->assertStringContainsString('foo.bar', $this->helper->getSuffix('foobar'));
         $this->assertNotEquals('bar.baz', $this->helper->getSuffix('barbaz'));
-        $this->assertContains('bar.baz', $this->helper->getSuffix('barbaz'));
+        $this->assertStringContainsString('bar.baz', $this->helper->getSuffix('barbaz'));
     }
 
     public function testCanRemoveSingleContext()
@@ -426,7 +426,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
             $this->helper->setDefaultContext('foobar');
             $this->fail('setDefaultContext() should raise exception if context does not exist');
         } catch (Zend_Controller_Action_Exception $e) {
-            $this->assertContains('Cannot set default context', $e->getMessage());
+            $this->assertStringContainsString('Cannot set default context', $e->getMessage());
         }
     }
 
@@ -486,13 +486,13 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
                       ->setActionName('all');
         $this->helper->initContext();
         $this->assertEquals('json', $this->helper->getCurrentContext());
-        $this->assertContains('json', $this->viewRenderer->getViewSuffix());
+        $this->assertStringContainsString('json', $this->viewRenderer->getViewSuffix());
 
         $this->request->setParam('format', 'xml')
                       ->setActionName('all');
         $this->helper->initContext();
         $this->assertEquals('xml', $this->helper->getCurrentContext());
-        $this->assertContains('xml', $this->viewRenderer->getViewSuffix());
+        $this->assertStringContainsString('xml', $this->viewRenderer->getViewSuffix());
     }
 
     public function testInitContextDoesNothingIfActionDoesNotHaveContextAndPassedFormatInvalid()
@@ -508,7 +508,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
         $this->request->setParam('format', 'xml')
                       ->setActionName('foo');
         $this->helper->initContext();
-        $this->assertContains('xml', $this->viewRenderer->getViewSuffix());
+        $this->assertStringContainsString('xml', $this->viewRenderer->getViewSuffix());
     }
 
     public function testInitContextSetsAppropriateResponseHeader()
@@ -535,7 +535,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
                       ->setActionName('foo');
         $this->helper->initContext('json');
 
-        $this->assertContains('json', $this->viewRenderer->getViewSuffix());
+        $this->assertStringContainsString('json', $this->viewRenderer->getViewSuffix());
 
         $headers = $this->response->getHeaders();
 
@@ -555,7 +555,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
         $this->request->setActionName('foo');
         $this->helper->initContext('xml');
 
-        $this->assertContains('xml', $this->viewRenderer->getViewSuffix());
+        $this->assertStringContainsString('xml', $this->viewRenderer->getViewSuffix());
 
         $headers = $this->response->getHeaders();
 
@@ -860,7 +860,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
         $this->helper->init();
         $this->helper->initContext();
         $suffix = $this->viewRenderer->getViewSuffix();
-        $this->assertNotContains('xml', $suffix, $suffix);
+        $this->assertStringNotContainsString('xml', $suffix, $suffix);
     }
 
     /**
@@ -876,15 +876,15 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends \PHPUnit\Framework
         $this->helper->initContext();
         $this->assertEquals('foo', $this->helper->getCurrentContext());
         $suffix = $this->viewRenderer->getViewSuffix();
-        $this->assertContains('foo', $suffix, $suffix);
+        $this->assertStringContainsString('foo', $suffix, $suffix);
 
         $this->request->setActionName('bar');
         $this->helper->init();
         $this->helper->initContext();
         $this->assertEquals('foo', $this->helper->getCurrentContext());
         $suffix = $this->viewRenderer->getViewSuffix();
-        $this->assertContains('foo', $suffix, $suffix);
-        $this->assertNotContains('foo.foo', $suffix, $suffix);
+        $this->assertStringContainsString('foo', $suffix, $suffix);
+        $this->assertStringNotContainsString('foo.foo', $suffix, $suffix);
     }
 
     /**

--- a/tests/Zend/Controller/Action/Helper/FlashMessengerTest.php
+++ b/tests/Zend/Controller/Action/Helper/FlashMessengerTest.php
@@ -69,7 +69,7 @@ class Zend_Controller_Action_Helper_FlashMessengerTest extends \PHPUnit\Framewor
      */
     public $response;
 
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Session::start();
 

--- a/tests/Zend/Controller/Action/Helper/JsonTest.php
+++ b/tests/Zend/Controller/Action/Helper/JsonTest.php
@@ -49,7 +49,7 @@ class Zend_Controller_Action_Helper_JsonTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Controller_Action_Helper_JsonTest_Layout::resetMvcInstance();
 
@@ -72,7 +72,7 @@ class Zend_Controller_Action_Helper_JsonTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 

--- a/tests/Zend/Controller/Action/Helper/RedirectorTest.php
+++ b/tests/Zend/Controller/Action/Helper/RedirectorTest.php
@@ -69,7 +69,7 @@ class Zend_Controller_Action_Helper_RedirectorTest extends \PHPUnit\Framework\Te
      *
      * Also resets the front controller instance.
      */
-    public function setUp()
+    public function setUp(): void
     {
         $front = Zend_Controller_Front::getInstance();
         $front->resetInstance();
@@ -99,7 +99,7 @@ class Zend_Controller_Action_Helper_RedirectorTest extends \PHPUnit\Framework\Te
     /**
      * Unset all properties
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->redirector);
         unset($this->controller);
@@ -483,7 +483,7 @@ class Zend_Controller_Action_Helper_RedirectorTest extends \PHPUnit\Framework\Te
         $this->redirector->gotoUrl('/bar/baz');
         $test = $this->redirector->getRedirectUrl();
 
-        $this->assertNotContains('https://', $test);
+        $this->assertStringNotContainsString('https://', $test);
         $this->assertEquals('http://localhost/bar/baz', $test);
     }
 

--- a/tests/Zend/Controller/Action/Helper/UrlTest.php
+++ b/tests/Zend/Controller/Action/Helper/UrlTest.php
@@ -46,7 +46,7 @@ class Zend_Controller_Action_Helper_UrlTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->front = Zend_Controller_Front::getInstance();
         $this->front->resetInstance();
@@ -60,7 +60,7 @@ class Zend_Controller_Action_Helper_UrlTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -69,8 +69,8 @@ class Zend_Controller_Action_Helper_UrlTest extends \PHPUnit\Framework\TestCase
     {
         $url = $this->helper->simple('baz', 'bar', 'foo', array('bat' => 'foo', 'ho' => 'hum'));
         $this->assertEquals('/foo/bar/baz', substr($url, 0, 12));
-        $this->assertContains('/bat/foo', $url);
-        $this->assertContains('/ho/hum', $url);
+        $this->assertStringContainsString('/bat/foo', $url);
+        $this->assertStringContainsString('/ho/hum', $url);
     }
 
     public function testSimpleWithMissingControllerAndModuleProducesAppropriateUrl()
@@ -80,8 +80,8 @@ class Zend_Controller_Action_Helper_UrlTest extends \PHPUnit\Framework\TestCase
                 ->setControllerName('bar');
         $url = $this->helper->simple('baz', null, null, array('bat' => 'foo', 'ho' => 'hum'));
         $this->assertEquals('/foo/bar/baz', substr($url, 0, 12));
-        $this->assertContains('/bat/foo', $url);
-        $this->assertContains('/ho/hum', $url);
+        $this->assertStringContainsString('/bat/foo', $url);
+        $this->assertStringContainsString('/ho/hum', $url);
     }
 
     public function testSimpleWithDefaultModuleProducesUrlWithoutModuleSegment()
@@ -136,16 +136,16 @@ class Zend_Controller_Action_Helper_UrlTest extends \PHPUnit\Framework\TestCase
             'ho'         => 'hum'
         ));
         $this->assertEquals('/foo/bar/baz', substr($url, 0, 12));
-        $this->assertContains('/bat/foo', $url);
-        $this->assertContains('/ho/hum', $url);
+        $this->assertStringContainsString('/bat/foo', $url);
+        $this->assertStringContainsString('/ho/hum', $url);
     }
 
     public function testDirectProxiesToSimple()
     {
         $url = $this->helper->direct('baz', 'bar', 'foo', array('bat' => 'foo', 'ho' => 'hum'));
         $this->assertEquals('/foo/bar/baz', substr($url, 0, 12));
-        $this->assertContains('/bat/foo', $url);
-        $this->assertContains('/ho/hum', $url);
+        $this->assertStringContainsString('/bat/foo', $url);
+        $this->assertStringContainsString('/ho/hum', $url);
     }
 
     /**

--- a/tests/Zend/Controller/Action/Helper/ViewRendererTest.php
+++ b/tests/Zend/Controller/Action/Helper/ViewRendererTest.php
@@ -80,7 +80,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->basePath = realpath(dirname(__FILE__) . str_repeat(DIRECTORY_SEPARATOR . '..', 2));
         $this->request  = new Zend_Controller_Request_Http();
@@ -101,7 +101,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
      *
      * @access protected
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Zend_Controller_Action_HelperBroker::resetHelpers();
     }
@@ -156,7 +156,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
 
         $scriptPaths = $this->helper->view->getScriptPaths();
         $this->assertEquals($count, count($scriptPaths), var_export($scriptPaths, 1));
-        $this->assertContains($module, $scriptPaths[0]);
+        $this->assertStringContainsString($module, $scriptPaths[0]);
 
         $helperPaths = $this->helper->view->getHelperPaths();
         $test        = ucfirst($module) . '_View_Helper_';
@@ -259,7 +259,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
 
         $scriptPaths = $this->helper->view->getScriptPaths();
         $scriptPath  = $scriptPaths[0];
-        $this->assertContains(
+        $this->assertStringContainsString(
             $this->_normalizePath($viewDir),
             $this->_normalizePath($scriptPath)
             );
@@ -306,7 +306,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $this->helper->postDispatch();
 
         $content = $this->response->getBody();
-        $this->assertNotContains('Rendered index/test.phtml', $this->response->getBody());
+        $this->assertStringNotContainsString('Rendered index/test.phtml', $this->response->getBody());
     }
 
     public function testNoRenderFlag()
@@ -384,7 +384,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $this->helper->postDispatch();
 
         $content = $this->response->getBody();
-        $this->assertContains('Rendered index/test.phtml in bar module', $content);
+        $this->assertStringContainsString('Rendered index/test.phtml in bar module', $content);
     }
 
     public function testPostDispatchDoesNothingOnForward()
@@ -398,7 +398,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $this->helper->postDispatch();
 
         $content = $this->response->getBody();
-        $this->assertNotContains('Rendered index/test.phtml in bar module', $content);
+        $this->assertStringNotContainsString('Rendered index/test.phtml in bar module', $content);
         $this->assertTrue(empty($content));
     }
 
@@ -414,7 +414,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $this->helper->postDispatch();
 
         $content = $this->response->getBody();
-        $this->assertNotContains('Rendered index/test.phtml in bar module', $content);
+        $this->assertStringNotContainsString('Rendered index/test.phtml in bar module', $content);
         $this->assertTrue(empty($content));
     }
 
@@ -427,7 +427,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $this->helper->postDispatch();
 
         $content = $this->response->getBody();
-        $this->assertNotContains('Rendered index/test.phtml in bar module', $content);
+        $this->assertStringNotContainsString('Rendered index/test.phtml in bar module', $content);
         $this->assertTrue(empty($content));
     }
 
@@ -441,7 +441,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $this->helper->postDispatch();
 
         $content = $this->response->getBody();
-        $this->assertNotContains('Rendered index/test.phtml in bar module', $content);
+        $this->assertStringNotContainsString('Rendered index/test.phtml in bar module', $content);
         $this->assertTrue(empty($content));
     }
 
@@ -539,7 +539,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $controller = new Bar_IndexController($this->request, $this->response, array());
         $this->helper->renderScript('index/test.phtml');
         $body = $this->response->getBody();
-        $this->assertContains('Rendered index/test.phtml in bar module', $body);
+        $this->assertStringContainsString('Rendered index/test.phtml in bar module', $body);
     }
 
     public function testRenderScriptToNamedResponseSegment()
@@ -550,7 +550,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $controller = new Bar_IndexController($this->request, $this->response, array());
         $this->helper->renderScript('index/test.phtml', 'foo');
         $body = $this->response->getBody('foo');
-        $this->assertContains('Rendered index/test.phtml in bar module', $body);
+        $this->assertStringContainsString('Rendered index/test.phtml in bar module', $body);
     }
 
     public function testRenderScriptToPreviouslyNamedResponseSegment()
@@ -562,7 +562,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $this->helper->setResponseSegment('foo');
         $this->helper->renderScript('index/test.phtml');
         $body = $this->response->getBody('foo');
-        $this->assertContains('Rendered index/test.phtml in bar module', $body);
+        $this->assertStringContainsString('Rendered index/test.phtml in bar module', $body);
     }
 
     public function testRenderWithDefaults()
@@ -573,7 +573,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $controller = new Bar_IndexController($this->request, $this->response, array());
         $this->helper->render();
         $body = $this->response->getBody();
-        $this->assertContains('Rendered index/test.phtml in bar module', $body);
+        $this->assertStringContainsString('Rendered index/test.phtml in bar module', $body);
     }
 
     public function testRenderToSpecifiedAction()
@@ -584,7 +584,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $controller = new Bar_IndexController($this->request, $this->response, array());
         $this->helper->render('test');
         $body = $this->response->getBody();
-        $this->assertContains('Rendered index/test.phtml in bar module', $body);
+        $this->assertStringContainsString('Rendered index/test.phtml in bar module', $body);
     }
 
     public function testRenderWithNoController()
@@ -595,7 +595,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $controller = new Bar_IndexController($this->request, $this->response, array());
         $this->helper->render(null, null, true);
         $body = $this->response->getBody();
-        $this->assertContains('Rendered test.phtml in bar module', $body);
+        $this->assertStringContainsString('Rendered test.phtml in bar module', $body);
     }
 
     public function testRenderToNamedSegment()
@@ -606,7 +606,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $controller = new Bar_IndexController($this->request, $this->response, array());
         $this->helper->render(null, 'foo');
         $body = $this->response->getBody('foo');
-        $this->assertContains('Rendered index/test.phtml in bar module', $body);
+        $this->assertStringContainsString('Rendered index/test.phtml in bar module', $body);
     }
 
     public function testRenderBySpec()
@@ -617,7 +617,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $controller = new Bar_IndexController($this->request, $this->response, array());
         $this->helper->renderBySpec('foo', array('controller' => 'test', 'suffix' => 'php'));
         $body = $this->response->getBody();
-        $this->assertContains('Rendered test/foo.php', $body);
+        $this->assertStringContainsString('Rendered test/foo.php', $body);
     }
 
     public function testRenderBySpecToNamedResponseSegment()
@@ -628,7 +628,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
         $controller = new Bar_IndexController($this->request, $this->response, array());
         $this->helper->renderBySpec('foo', array('controller' => 'test', 'suffix' => 'php'), 'foo');
         $body = $this->response->getBody('foo');
-        $this->assertContains('Rendered test/foo.php', $body);
+        $this->assertStringContainsString('Rendered test/foo.php', $body);
     }
 
     public function testInitDoesNotInitViewWhenNoViewRendererSet()
@@ -714,7 +714,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
 
         $this->helper->render();
         $body = $this->response->getBody();
-        $this->assertContains('Rendered test.phtml in bar module', $body);
+        $this->assertStringContainsString('Rendered test.phtml in bar module', $body);
     }
 
     public function testCustomInflectorUsesViewRendererTargetWhenPassedInWithReferenceFlag()
@@ -743,7 +743,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
 
         $this->helper->render();
         $body = $this->response->getBody();
-        $this->assertContains('Rendered index/test.phtml in bar module', $body);
+        $this->assertStringContainsString('Rendered index/test.phtml in bar module', $body);
     }
 
     public function testStockInflectorAllowsSubDirectoryViewScripts()
@@ -808,7 +808,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
 
         $this->helper->render();
         $body = $this->response->getBody();
-        $this->assertContains('fooUseHelper invoked', $body, 'Received ' . $body);
+        $this->assertStringContainsString('fooUseHelper invoked', $body, 'Received ' . $body);
     }
 
     /**
@@ -834,7 +834,7 @@ class Zend_Controller_Action_Helper_ViewRendererTest extends \PHPUnit\Framework\
 
         $this->helper->render();
         $body = $this->response->getBody();
-        $this->assertContains('SampleZfHelper invoked', $body, 'Received ' . $body);
+        $this->assertStringContainsString('SampleZfHelper invoked', $body, 'Received ' . $body);
     }
 
     /**

--- a/tests/Zend/Controller/Action/HelperBroker/PriorityStackTest.php
+++ b/tests/Zend/Controller/Action/HelperBroker/PriorityStackTest.php
@@ -42,7 +42,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStackTest extends \PHPUnit\Fra
      */
     public $stack = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->stack = new Zend_Controller_Action_HelperBroker_PriorityStack();
     }

--- a/tests/Zend/Controller/Action/HelperBrokerTest.php
+++ b/tests/Zend/Controller/Action/HelperBrokerTest.php
@@ -45,7 +45,7 @@ class Zend_Controller_Action_HelperBrokerTest extends \PHPUnit\Framework\TestCas
      */
     protected $front;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->front = Zend_Controller_Front::getInstance();
         $this->front->resetInstance();
@@ -169,7 +169,7 @@ class Zend_Controller_Action_HelperBrokerTest extends \PHPUnit\Framework\TestCas
 
         $this->front->returnResponse(true);
         $response = $this->front->dispatch($request);
-        $this->assertContains('not found', $response->getBody());
+        $this->assertStringContainsString('not found', $response->getBody());
     }
 
     public function testCustomHelperRegistered()

--- a/tests/Zend/Controller/ActionTest.php
+++ b/tests/Zend/Controller/ActionTest.php
@@ -38,7 +38,7 @@ require_once 'Zend/Controller/Response/Cli.php';
 class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Controller_Action_HelperBroker::resetHelpers();
         $front = Zend_Controller_Front::getInstance();
@@ -58,7 +58,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
         $redirector->setExit(false);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->_controller);
     }
@@ -72,21 +72,21 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
     public function testPreRun()
     {
         $this->_controller->preDispatch();
-        $this->assertNotContains('Prerun ran', $this->_controller->getResponse()->getBody());
+        $this->assertStringNotContainsString('Prerun ran', $this->_controller->getResponse()->getBody());
 
         $this->_controller->getRequest()->setParam('prerun', true);
         $this->_controller->preDispatch();
-        $this->assertContains('Prerun ran', $this->_controller->getResponse()->getBody());
+        $this->assertStringContainsString('Prerun ran', $this->_controller->getResponse()->getBody());
     }
 
     public function testPostRun()
     {
         $this->_controller->postDispatch();
-        $this->assertNotContains('Postrun ran', $this->_controller->getResponse()->getBody());
+        $this->assertStringNotContainsString('Postrun ran', $this->_controller->getResponse()->getBody());
 
         $this->_controller->getRequest()->setParam('postrun', true);
         $this->_controller->postDispatch();
-        $this->assertContains('Postrun ran', $this->_controller->getResponse()->getBody());
+        $this->assertStringContainsString('Postrun ran', $this->_controller->getResponse()->getBody());
     }
 
     public function testGetRequest()
@@ -169,8 +169,8 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
     {
         $response = $this->_controller->run();
         $body     = $response->getBody();
-        $this->assertContains('In the index action', $body, var_export($this->_controller->getRequest(), 1));
-        $this->assertNotContains('Prerun ran', $body, $body);
+        $this->assertStringContainsString('In the index action', $body, var_export($this->_controller->getRequest(), 1));
+        $this->assertStringNotContainsString('Prerun ran', $body, $body);
     }
 
     public function testRun2()
@@ -188,8 +188,8 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
     {
         $this->_controller->getRequest()->setActionName('foo');
         $response = $this->_controller->run();
-        $this->assertContains('In the foo action', $response->getBody());
-        $this->assertNotContains('Prerun ran', $this->_controller->getResponse()->getBody());
+        $this->assertStringContainsString('In the foo action', $response->getBody());
+        $this->assertStringNotContainsString('Prerun ran', $this->_controller->getResponse()->getBody());
     }
 
     public function testHasParam()
@@ -262,7 +262,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
             }
         }
         $this->assertEquals(1, $found);
-        $this->assertContains('/foo/bar', $url);
+        $this->assertStringContainsString('/foo/bar', $url);
     }
 
     public function testInitView()
@@ -291,7 +291,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
         $controller = new ViewController($request, $response);
 
         $controller->indexAction();
-        $this->assertContains('In the index action view', $response->getBody());
+        $this->assertStringContainsString('In the index action view', $response->getBody());
     }
 
     public function testRenderByName()
@@ -305,7 +305,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
         $controller = new ViewController($request, $response);
 
         $controller->testAction();
-        $this->assertContains('In the index action view', $response->getBody());
+        $this->assertStringContainsString('In the index action view', $response->getBody());
     }
 
     public function testRenderOutsideControllerSubdir()
@@ -319,7 +319,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
         $controller = new ViewController($request, $response);
 
         $controller->siteAction();
-        $this->assertContains('In the sitewide view', $response->getBody());
+        $this->assertStringContainsString('In the sitewide view', $response->getBody());
     }
 
     public function testRenderNamedSegment()
@@ -333,7 +333,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
         $controller = new ViewController($request, $response);
 
         $controller->nameAction();
-        $this->assertContains('In the name view', $response->getBody('name'));
+        $this->assertStringContainsString('In the name view', $response->getBody('name'));
     }
 
     public function testRenderNormalizesScriptName()
@@ -347,7 +347,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
         $controller = new FooBarController($request, $response);
 
         $controller->bazBatAction();
-        $this->assertContains('Inside foo-bar/baz-bat.phtml', $response->getBody());
+        $this->assertStringContainsString('Inside foo-bar/baz-bat.phtml', $response->getBody());
     }
 
     public function testGetViewScript()
@@ -361,10 +361,10 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
         $controller = new ViewController($request, $response);
 
         $script = $controller->getViewScript();
-        $this->assertContains('view' . DIRECTORY_SEPARATOR . 'test.phtml', $script);
+        $this->assertStringContainsString('view' . DIRECTORY_SEPARATOR . 'test.phtml', $script);
 
         $script = $controller->getViewScript('foo');
-        $this->assertContains('view' . DIRECTORY_SEPARATOR . 'foo.phtml', $script);
+        $this->assertStringContainsString('view' . DIRECTORY_SEPARATOR . 'foo.phtml', $script);
     }
 
     public function testGetViewScriptDoesNotOverwriteNoControllerFlagWhenNullPassed()
@@ -400,7 +400,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
         $controller = new ViewController($request, $response);
 
         $controller->scriptAction();
-        $this->assertContains('Inside custom/renderScript.php', $response->getBody());
+        $this->assertStringContainsString('Inside custom/renderScript.php', $response->getBody());
     }
 
     public function testRenderScriptToNamedResponseSegment()
@@ -415,7 +415,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
 
         $controller->scriptNameAction();
 
-        $this->assertContains('Inside custom/renderScript.php', $response->getBody('foo'));
+        $this->assertStringContainsString('Inside custom/renderScript.php', $response->getBody('foo'));
     }
 
     public function testGetHelper()
@@ -458,7 +458,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
         $controller = new ViewController($request, $response);
 
         $controller->scriptAction();
-        $this->assertContains('Inside custom/renderScript.php', $response->getBody());
+        $this->assertStringContainsString('Inside custom/renderScript.php', $response->getBody());
     }
 
     public function testMissingActionExceptionsDifferFromMissingMethods()
@@ -468,8 +468,8 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
             $this->fail('Invalid action should throw exception');
         } catch (Zend_Controller_Exception $e) {
             $this->assertRegexp('/^Action.*?(does not exist and was not trapped in __call\(\))$/', $e->getMessage());
-            $this->assertContains('bogus', $e->getMessage());
-            $this->assertNotContains('bogusAction', $e->getMessage());
+            $this->assertStringContainsString('bogus', $e->getMessage());
+            $this->assertStringNotContainsString('bogusAction', $e->getMessage());
             $this->assertEquals(404, $e->getCode());
         }
 
@@ -478,7 +478,7 @@ class Zend_Controller_ActionTest extends \PHPUnit\Framework\TestCase
             $this->fail('Invalid method should throw exception');
         } catch (Zend_Controller_Exception $e) {
             $this->assertRegexp('/^Method.*?(does not exist and was not trapped in __call\(\))$/', $e->getMessage());
-            $this->assertContains('bogus', $e->getMessage());
+            $this->assertStringContainsString('bogus', $e->getMessage());
             $this->assertEquals(500, $e->getCode());
         }
     }

--- a/tests/Zend/Controller/Dispatcher/StandardTest.php
+++ b/tests/Zend/Controller/Dispatcher/StandardTest.php
@@ -40,7 +40,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
 {
     protected $_dispatcher;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (isset($this->error)) {
             unset($this->error);
@@ -55,7 +55,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         ));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->_dispatcher);
     }
@@ -180,7 +180,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $response = new Zend_Controller_Response_Cli();
         $this->_dispatcher->dispatch($request, $response);
 
-        $this->assertContains('Index action called', $this->_dispatcher->getResponse()->getBody());
+        $this->assertStringContainsString('Index action called', $this->_dispatcher->getResponse()->getBody());
     }
 
     public function testDispatchValidControllerAndAction()
@@ -191,7 +191,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $response = new Zend_Controller_Response_Cli();
         $this->_dispatcher->dispatch($request, $response);
 
-        $this->assertContains('Index action called', $this->_dispatcher->getResponse()->getBody());
+        $this->assertStringContainsString('Index action called', $this->_dispatcher->getResponse()->getBody());
     }
 
     public function testDispatchValidControllerWithInvalidAction()
@@ -291,9 +291,9 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $this->_dispatcher->dispatch($request, $response);
 
         $body = $this->_dispatcher->getResponse()->getBody();
-        $this->assertContains('Bar action called', $body);
-        $this->assertContains('preDispatch called', $body);
-        $this->assertContains('postDispatch called', $body);
+        $this->assertStringContainsString('Bar action called', $body);
+        $this->assertStringContainsString('preDispatch called', $body);
+        $this->assertStringContainsString('postDispatch called', $body);
     }
 
     public function testDispatchNoControllerUsesDefaults()
@@ -344,7 +344,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $response = new Zend_Controller_Response_Cli();
         $this->_dispatcher->dispatch($request, $response);
         $body = $this->_dispatcher->getResponse()->getBody();
-        $this->assertContains("Admin_Foo::bar action called", $body, $body);
+        $this->assertStringContainsString("Admin_Foo::bar action called", $body, $body);
     }
 
     public function testModuleControllerInSubdirWithCamelCaseAction()
@@ -359,7 +359,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $response = new Zend_Controller_Response_Cli();
         $this->_dispatcher->dispatch($request, $response);
         $body = $this->_dispatcher->getResponse()->getBody();
-        $this->assertContains("Admin_FooBar::bazBat action called", $body, $body);
+        $this->assertStringContainsString("Admin_FooBar::bazBat action called", $body, $body);
     }
 
     public function testUseModuleDefaultController()
@@ -375,7 +375,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $response = new Zend_Controller_Response_Cli();
         $this->_dispatcher->dispatch($request, $response);
         $body = $this->_dispatcher->getResponse()->getBody();
-        $this->assertContains("Admin_Foo::index action called", $body, $body);
+        $this->assertStringContainsString("Admin_Foo::index action called", $body, $body);
     }
 
     public function testNoModuleOrControllerDefaultsCorrectly()
@@ -387,7 +387,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $response = new Zend_Controller_Response_Cli();
         $this->_dispatcher->dispatch($request, $response);
         $body = $this->_dispatcher->getResponse()->getBody();
-        $this->assertContains("Index action called", $body, $body);
+        $this->assertStringContainsString("Index action called", $body, $body);
     }
 
     public function testOutputBuffering()
@@ -401,7 +401,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $response = new Zend_Controller_Response_Cli();
         $this->_dispatcher->dispatch($request, $response);
         $body = $this->_dispatcher->getResponse()->getBody();
-        $this->assertContains("OB index action called", $body, $body);
+        $this->assertStringContainsString("OB index action called", $body, $body);
     }
 
     public function testDisableOutputBuffering()
@@ -438,7 +438,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $response = new Zend_Controller_Response_Cli();
         $this->_dispatcher->dispatch($request, $response);
         $body = $this->_dispatcher->getResponse()->getBody();
-        $this->assertContains("Foo_Admin_IndexController::indexAction() called", $body, $body);
+        $this->assertStringContainsString("Foo_Admin_IndexController::indexAction() called", $body, $body);
     }
 
     public function testDefaultModule()
@@ -481,8 +481,8 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         } catch (Exception $e) {
         }
         $body = $this->_dispatcher->getResponse()->getBody();
-        $this->assertNotContains("In exception action", $body, $body);
-        $this->assertNotContains("Foo", $body, $body);
+        $this->assertStringNotContainsString("In exception action", $body, $body);
+        $this->assertStringNotContainsString("Foo", $body, $body);
     }
 
     public function testGetDefaultControllerClassResetsRequestObject()
@@ -556,7 +556,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         $response = new Zend_Controller_Response_Cli();
         $dispatcher->dispatch($request, $response);
         $body = $dispatcher->getResponse()->getBody();
-        $this->assertContains("BazBat_FooController::indexAction() called", $body, $body);
+        $this->assertStringContainsString("BazBat_FooController::indexAction() called", $body, $body);
     }
 
     public function testLoadClassLoadsControllerInDefaultModuleWithModulePrefixWhenRequested()
@@ -606,7 +606,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
             $this->_dispatcher->dispatch($request, $response);
             $this->fail('Invalid camelCased action should raise exception');
         } catch (Zend_Controller_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
     }
 
@@ -628,7 +628,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
             $this->_dispatcher->dispatch($request, $response);
             $body = $this->_dispatcher->getResponse()->getBody();
             error_reporting($oldLevel);
-            $this->assertContains("Admin_FooBar::bazBat action called", $body, $body);
+            $this->assertStringContainsString("Admin_FooBar::bazBat action called", $body, $body);
         } catch (Zend_Controller_Exception $e) {
             error_reporting($oldLevel);
             $this->fail('camelCased actions should succeed when forced');
@@ -659,7 +659,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
             $body = $this->_dispatcher->getResponse()->getBody();
             restore_error_handler();
             $this->assertTrue(isset($this->error));
-            $this->assertContains('deprecated', $this->error);
+            $this->assertStringContainsString('deprecated', $this->error);
         } catch (Zend_Controller_Exception $e) {
             restore_error_handler();
             $this->fail('camelCased actions should succeed when forced');
@@ -678,7 +678,7 @@ class Zend_Controller_Dispatcher_StandardTest extends \PHPUnit\Framework\TestCas
         try {
             $class = $this->_dispatcher->getControllerClass($request);
         } catch (Zend_Controller_Exception $e) {
-            $this->assertContains('No default module', $e->getMessage());
+            $this->assertStringContainsString('No default module', $e->getMessage());
         }
     }
 }

--- a/tests/Zend/Controller/FrontTest.php
+++ b/tests/Zend/Controller/FrontTest.php
@@ -50,7 +50,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
 {
     protected $_controller = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_controller = Zend_Controller_Front::getInstance();
         $this->_controller->resetInstance();
@@ -62,7 +62,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         Zend_Controller_Action_HelperBroker::resetHelpers();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->_controller);
     }
@@ -253,7 +253,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $this->_controller->setResponse(new Zend_Controller_Response_Cli());
         $response = $this->_controller->dispatch($request);
 
-        $this->assertContains('Index action called', $response->getBody());
+        $this->assertStringContainsString('Index action called', $response->getBody());
     }
 
     /**
@@ -265,7 +265,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $this->_controller->setResponse(new Zend_Controller_Response_Cli());
         $response = $this->_controller->dispatch($request);
 
-        $this->assertContains('Index action called', $response->getBody());
+        $this->assertStringContainsString('Index action called', $response->getBody());
     }
 
     /**
@@ -312,9 +312,9 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $response = $this->_controller->dispatch($request);
 
         $body = $response->getBody();
-        $this->assertContains('Bar action called', $body, $body);
-        $this->assertContains('preDispatch called', $body, $body);
-        $this->assertContains('postDispatch called', $body, $body);
+        $this->assertStringContainsString('Bar action called', $body, $body);
+        $this->assertStringContainsString('preDispatch called', $body, $body);
+        $this->assertStringContainsString('postDispatch called', $body, $body);
     }
 
     /**
@@ -329,8 +329,8 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $response = $this->_controller->dispatch($request);
 
         $body = $response->getBody();
-        $this->assertContains('foo: bar', $body, $body);
-        $this->assertContains('baz: bat', $body);
+        $this->assertStringContainsString('foo: bar', $body, $body);
+        $this->assertStringContainsString('baz: bat', $body);
     }
 
     /**
@@ -344,7 +344,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $response = $this->_controller->dispatch($request);
 
         $body = $response->getBody();
-        $this->assertContains('Bar action called', $body);
+        $this->assertStringContainsString('Bar action called', $body);
         $params = $request->getParams();
         $this->assertTrue(isset($params['var1']));
         $this->assertEquals('baz', $params['var1']);
@@ -364,7 +364,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $response = $this->_controller->dispatch($request, $response);
 
         $body = $response->getBody();
-        $this->assertContains('Bar action called', $body);
+        $this->assertStringContainsString('Bar action called', $body);
     }
 
     /**
@@ -421,7 +421,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $response = new Zend_Controller_Response_Cli();
         $response = $this->_controller->dispatch($request, $response);
 
-        $this->assertContains('index.php', $request->getBaseUrl());
+        $this->assertStringContainsString('index.php', $request->getBaseUrl());
     }
 
     /**
@@ -492,7 +492,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $body = ob_get_clean();
 
         $actual = $this->_controller->getResponse()->getBody();
-        $this->assertContains($actual, $body);
+        $this->assertStringContainsString($actual, $body);
     }
 
     public function testRunStatically()
@@ -517,7 +517,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $response = $this->_controller->dispatch($request);
 
         $body = $response->getBody();
-        $this->assertContains('Admin_Foo::bar action called', $body, $body);
+        $this->assertStringContainsString('Admin_Foo::bar action called', $body, $body);
     }
 
     public function testModuleControllerDirectoryName()
@@ -537,9 +537,9 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(isset($controllerDirs['default']));
         $this->assertFalse(isset($controllerDirs['.svn']));
 
-        $this->assertContains('modules' . DIRECTORY_SEPARATOR . 'foo', $controllerDirs['foo']);
-        $this->assertContains('modules' . DIRECTORY_SEPARATOR . 'bar', $controllerDirs['bar']);
-        $this->assertContains('modules' . DIRECTORY_SEPARATOR . 'default', $controllerDirs['default']);
+        $this->assertStringContainsString('modules' . DIRECTORY_SEPARATOR . 'foo', $controllerDirs['foo']);
+        $this->assertStringContainsString('modules' . DIRECTORY_SEPARATOR . 'bar', $controllerDirs['bar']);
+        $this->assertStringContainsString('modules' . DIRECTORY_SEPARATOR . 'default', $controllerDirs['default']);
     }
 
     /**#@+
@@ -552,16 +552,16 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $request->setModuleName('bar');
         $this->_controller->setRequest($request);
         $dir = $this->_controller->getModuleDirectory();
-        $this->assertContains('modules' . DIRECTORY_SEPARATOR . 'bar', $dir);
-        $this->assertNotContains('controllers', $dir);
+        $this->assertStringContainsString('modules' . DIRECTORY_SEPARATOR . 'bar', $dir);
+        $this->assertStringNotContainsString('controllers', $dir);
     }
 
     public function testShouldAllowRetrievingSpecifiedModuleDirectory()
     {
         $this->testAddModuleDirectory();
         $dir = $this->_controller->getModuleDirectory('foo');
-        $this->assertContains('modules' . DIRECTORY_SEPARATOR . 'foo', $dir);
-        $this->assertNotContains('controllers', $dir);
+        $this->assertStringContainsString('modules' . DIRECTORY_SEPARATOR . 'foo', $dir);
+        $this->assertStringNotContainsString('controllers', $dir);
     }
 
     public function testShouldReturnNullWhenRetrievingNonexistentModuleDirectory()
@@ -605,7 +605,7 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $this->_controller->addModuleDirectory($moduleDir);
         $barDir = $this->_controller->getControllerDirectory('bar');
         $this->assertNotNull($barDir);
-        $this->assertContains('modules' . DIRECTORY_SEPARATOR . 'bar', $barDir);
+        $this->assertStringContainsString('modules' . DIRECTORY_SEPARATOR . 'bar', $barDir);
     }
 
     public function testGetControllerDirectoryByModuleNameReturnsNullOnBadModule()
@@ -659,8 +659,8 @@ class Zend_Controller_FrontTest extends \PHPUnit\Framework\TestCase
         $this->assertNotSame($request, $requestPost);
         $this->assertNotSame($response, $responsePost);
 
-        $this->assertContains('Reset action called', $responsePost->getBody());
-        $this->assertNotContains('Reset action called', $response->getBody());
+        $this->assertStringContainsString('Reset action called', $responsePost->getBody());
+        $this->assertStringNotContainsString('Reset action called', $response->getBody());
     }
 
     public function testViewRendererHelperRegisteredWhenDispatched()

--- a/tests/Zend/Controller/Plugin/ActionStackTest.php
+++ b/tests/Zend/Controller/Plugin/ActionStackTest.php
@@ -46,7 +46,7 @@ class Zend_Controller_Plugin_ActionStackTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->removeRegistryEntry();
         $this->registry = Zend_Registry::getInstance();
@@ -58,7 +58,7 @@ class Zend_Controller_Plugin_ActionStackTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->removeRegistryEntry();
     }

--- a/tests/Zend/Controller/Plugin/BrokerTest.php
+++ b/tests/Zend/Controller/Plugin/BrokerTest.php
@@ -47,7 +47,7 @@ class Zend_Controller_Plugin_BrokerTest extends \PHPUnit\Framework\TestCase
 {
     public $controller;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->controller = Zend_Controller_Front::getInstance();
         $this->controller->resetInstance();
@@ -64,7 +64,7 @@ class Zend_Controller_Plugin_BrokerTest extends \PHPUnit\Framework\TestCase
             $broker->registerPlugin($plugin);
             $this->fail('Duplicate registry of plugin object should be disallowed');
         } catch (Exception $expected) {
-            $this->assertContains('already', $expected->getMessage());
+            $this->assertStringContainsString('already', $expected->getMessage());
         }
     }
 

--- a/tests/Zend/Controller/Plugin/ErrorHandlerTest.php
+++ b/tests/Zend/Controller/Plugin/ErrorHandlerTest.php
@@ -74,7 +74,7 @@ class Zend_Controller_Plugin_ErrorHandlerTest extends \PHPUnit\Framework\TestCas
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Zend_Controller_Front::getInstance()->resetInstance();
         $this->request  = new Zend_Controller_Request_Http();
@@ -91,7 +91,7 @@ class Zend_Controller_Plugin_ErrorHandlerTest extends \PHPUnit\Framework\TestCas
      *
      * @access protected
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
     }
 

--- a/tests/Zend/Controller/Plugin/PutHandlerTest.php
+++ b/tests/Zend/Controller/Plugin/PutHandlerTest.php
@@ -56,7 +56,7 @@ class Zend_Controller_Plugin_PutHandlerTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         Zend_Controller_Front::getInstance()->resetInstance();
         $this->request  = new Zend_Controller_Request_HttpTestCase();

--- a/tests/Zend/Controller/Request/Apache404Test.php
+++ b/tests/Zend/Controller/Request/Apache404Test.php
@@ -42,12 +42,12 @@ class Zend_Controller_Request_Apache404Test extends \PHPUnit\Framework\TestCase
      */
     protected $_server;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_server = $_SERVER;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $_SERVER = $this->_server;
     }

--- a/tests/Zend/Controller/Request/HttpTest.php
+++ b/tests/Zend/Controller/Request/HttpTest.php
@@ -44,7 +44,7 @@ class Zend_Controller_Request_HttpTest extends \PHPUnit\Framework\TestCase
      */
     protected $_origServer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_origServer = $_SERVER;
         $_GET  = array();
@@ -57,7 +57,7 @@ class Zend_Controller_Request_HttpTest extends \PHPUnit\Framework\TestCase
         $this->_request = new Zend_Controller_Request_Http('http://framework.zend.com/news/3?var1=val1&var2=val2#anchor');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->_request);
         $_SERVER = $this->_origServer;

--- a/tests/Zend/Controller/Request/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Request/HttpTestCaseTest.php
@@ -42,7 +42,7 @@ class Zend_Controller_Request_HttpTestCaseTest extends \PHPUnit\Framework\TestCa
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->request = new Zend_Controller_Request_HttpTestCase();
         $_GET    = array();
@@ -56,7 +56,7 @@ class Zend_Controller_Request_HttpTestCaseTest extends \PHPUnit\Framework\TestCa
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 

--- a/tests/Zend/Controller/Response/HttpTest.php
+++ b/tests/Zend/Controller/Response/HttpTest.php
@@ -39,13 +39,13 @@ class Zend_Controller_Response_HttpTest extends \PHPUnit\Framework\TestCase
      */
     protected $_response;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_response = new Zend_Controller_Response_Http();
         $this->_response->headersSentThrowsException = false;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->_response);
     }
@@ -282,7 +282,7 @@ class Zend_Controller_Response_HttpTest extends \PHPUnit\Framework\TestCase
         ob_start();
         $this->_response->sendResponse();
         $string = ob_get_clean();
-        $this->assertContains('Test exception rendering', $string);
+        $this->assertStringContainsString('Test exception rendering', $string);
     }
 
     public function testSetResponseCodeThrowsExceptionWithBadCode()

--- a/tests/Zend/Controller/Response/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Response/HttpTestCaseTest.php
@@ -42,7 +42,7 @@ class Zend_Controller_Response_HttpTestCaseTest extends \PHPUnit\Framework\TestC
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->response = new Zend_Controller_Response_HttpTestCase();
     }
@@ -53,7 +53,7 @@ class Zend_Controller_Response_HttpTestCaseTest extends \PHPUnit\Framework\TestC
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
@@ -72,7 +72,7 @@ class Zend_Controller_Response_HttpTestCaseTest extends \PHPUnit\Framework\TestC
         $this->response->setHeader('X-Foo-Bar', 'baz')
                        ->setBody('Body to emit');
         $test = $this->response->sendResponse();
-        $this->assertContains("X-Foo-Bar: baz\n\nBody to emit", $test);
+        $this->assertStringContainsString("X-Foo-Bar: baz\n\nBody to emit", $test);
     }
 
     public function testOutputBodyShouldReturnStringInsteadOfEchoingOutput()
@@ -85,7 +85,7 @@ class Zend_Controller_Response_HttpTestCaseTest extends \PHPUnit\Framework\TestC
         $test = ob_get_clean();
         $this->assertTrue(empty($test));
         $this->assertFalse(empty($content));
-        $this->assertContains("Baz Content\nFoo Content\nBar Content\n", $content, $content);
+        $this->assertStringContainsString("Baz Content\nFoo Content\nBar Content\n", $content, $content);
     }
 
     public function testSendHeadersShouldReturnArrayOfHeadersInsteadOfSendingHeaders()

--- a/tests/Zend/Controller/Router/RewriteTest.php
+++ b/tests/Zend/Controller/Router/RewriteTest.php
@@ -58,7 +58,7 @@ class Zend_Controller_Router_RewriteTest extends \PHPUnit\Framework\TestCase
 {
     protected $_router;
 
-    public function setUp() {
+    public function setUp(): void {
         $this->_router = new Zend_Controller_Router_Rewrite();
         $front = Zend_Controller_Front::getInstance();
         $front->resetInstance();
@@ -67,7 +67,7 @@ class Zend_Controller_Router_RewriteTest extends \PHPUnit\Framework\TestCase
         $this->_router->setFrontController($front);
     }
 
-    public function tearDown() {
+    public function tearDown(): void {
         unset($this->_router);
     }
 

--- a/tests/Zend/Controller/Router/Route/HostnameTest.php
+++ b/tests/Zend/Controller/Router/Route/HostnameTest.php
@@ -99,7 +99,7 @@ class Zend_Controller_Router_Route_HostnameTest extends \PHPUnit\Framework\TestC
             $route->assemble();
             $this->fail('An expected Zend_Controller_Router_Exception has not been raised');
         } catch (Zend_Controller_Router_Exception $expected) {
-            $this->assertContains('subdomain is not specified', $expected->getMessage());
+            $this->assertStringContainsString('subdomain is not specified', $expected->getMessage());
         }
     }
 

--- a/tests/Zend/Controller/Router/Route/ModuleTest.php
+++ b/tests/Zend/Controller/Router/Route/ModuleTest.php
@@ -42,7 +42,7 @@ class Zend_Controller_Router_Route_ModuleTest extends \PHPUnit\Framework\TestCas
     protected $_dispatcher;
     protected $route;
 
-    public function setUp()
+    public function setUp(): void
     {
         $front = Zend_Controller_Front::getInstance();
         $front->resetInstance();
@@ -463,6 +463,6 @@ class Zend_Controller_Router_Route_ModuleTest extends \PHPUnit\Framework\TestCas
             'module' => 'default',
         );
         $url = $this->route->assemble($params);
-        $this->assertNotContains('"><script>alert(11639)<', $url);
+        $this->assertStringNotContainsString('"><script>alert(11639)<', $url);
     }
 }

--- a/tests/Zend/Controller/Router/RouteTest.php
+++ b/tests/Zend/Controller/Router/RouteTest.php
@@ -55,7 +55,7 @@ class Zend_Controller_Router_RouteTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         // Backup server array
         $this->_server = $_SERVER;
@@ -77,7 +77,7 @@ class Zend_Controller_Router_RouteTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore server array
         $_SERVER = $this->_server;

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -36,7 +36,7 @@ require_once 'Zend/Date.php';
 class Zend_Date_DateObjectTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->originalTimezone = date_default_timezone_get();
         date_default_timezone_set('Europe/Paris');
@@ -47,7 +47,7 @@ class Zend_Date_DateObjectTest extends \PHPUnit\Framework\TestCase
         Zend_Date_DateObjectTestHelper::setOptions(array('cache' => $this->_cache));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         date_default_timezone_set($this->originalTimezone);
         $this->_cache->clean(Zend_Cache::CLEANING_MODE_ALL);

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -44,7 +44,7 @@ class Zend_DateTest extends \PHPUnit\Framework\TestCase
     private $_cache = null;
     private $_orig  = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->originalTimezone = date_default_timezone_get();
         date_default_timezone_set('Asia/Karachi');
@@ -60,7 +60,7 @@ class Zend_DateTest extends \PHPUnit\Framework\TestCase
         Zend_Date::setOptions(array('format_type' => 'iso'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Date::setOptions($this->_orig);
         $this->_cache->clean(Zend_Cache::CLEANING_MODE_ALL);

--- a/tests/Zend/Db/Adapter/Pdo/TestCommon.php
+++ b/tests/Zend/Db/Adapter/Pdo/TestCommon.php
@@ -98,6 +98,6 @@ abstract class Zend_Db_Adapter_Pdo_TestCommon extends Zend_Db_Adapter_TestCommon
     {
         $string = "1\0";
         $value  = $this->_db->quote($string);
-        $this->assertNotContains("\0", $value);
+        $this->assertStringNotContainsString("\0", $value);
     }
 }

--- a/tests/Zend/Db/Adapter/StaticTest.php
+++ b/tests/Zend/Db/Adapter/StaticTest.php
@@ -63,7 +63,7 @@ class Zend_Db_Adapter_StaticTest extends \PHPUnit\Framework\TestCase
             $db = new Zend_Db_Adapter_Static('scalar');
             $this->fail('Expected exception not thrown');
         } catch (Exception $e) {
-            $this->assertContains('Adapter parameters must be in an array or a Zend_Config object', $e->getMessage());
+            $this->assertStringContainsString('Adapter parameters must be in an array or a Zend_Config object', $e->getMessage());
         }
     }
 
@@ -151,7 +151,7 @@ class Zend_Db_Adapter_StaticTest extends \PHPUnit\Framework\TestCase
             $db = Zend_Db::factory('Static', 'scalar');
             $this->fail('Expected exception not thrown');
         } catch (Exception $e) {
-            $this->assertContains('Adapter parameters must be in an array or a Zend_Config object', $e->getMessage());
+            $this->assertStringContainsString('Adapter parameters must be in an array or a Zend_Config object', $e->getMessage());
         }
     }
 
@@ -161,7 +161,7 @@ class Zend_Db_Adapter_StaticTest extends \PHPUnit\Framework\TestCase
             $db = Zend_Db::factory('Static');
             $this->fail('Expected exception not thrown');
         } catch (Exception $e) {
-            $this->assertContains('Configuration must have a key for \'dbname\' that names the database instance', $e->getMessage());
+            $this->assertStringContainsString('Configuration must have a key for \'dbname\' that names the database instance', $e->getMessage());
         }
     }
 
@@ -327,7 +327,7 @@ class Zend_Db_Adapter_StaticTest extends \PHPUnit\Framework\TestCase
                 );
         } catch (Exception $e) {
             set_include_path($oldIncludePath);
-            $this->assertContains('failed to open stream', $e->getMessage());
+            $this->assertStringContainsString('failed to open stream', $e->getMessage());
             return;
         }
 

--- a/tests/Zend/Db/Adapter/TestCommon.php
+++ b/tests/Zend/Db/Adapter/TestCommon.php
@@ -212,7 +212,7 @@ abstract class Zend_Db_Adapter_TestCommon extends Zend_Db_TestSetup
             $this->fail("Expected to catch $exceptionClass");
         } catch (Zend_Exception $e) {
             $this->assertTrue($e instanceof $exceptionClass, "Expected to catch $exceptionClass, got ".get_class($e));
-            $this->assertContains("Configuration array must have a key for '$param'", $e->getMessage());
+            $this->assertStringContainsString("Configuration array must have a key for '$param'", $e->getMessage());
         }
     }
 

--- a/tests/Zend/Db/Profiler/StaticTest.php
+++ b/tests/Zend/Db/Profiler/StaticTest.php
@@ -264,7 +264,7 @@ class Zend_Db_Profiler_StaticTest extends Zend_Db_TestSetup
                 );
             $this->fail('Expected Zend_Db_Profiler_Exception not thrown');
         } catch (Zend_Db_Profiler_Exception $e) {
-            $this->assertContains('Profiler argument must be an instance of', $e->getMessage());
+            $this->assertStringContainsString('Profiler argument must be an instance of', $e->getMessage());
         }
     }
 
@@ -518,7 +518,7 @@ class Zend_Db_Profiler_StaticTest extends Zend_Db_TestSetup
             $prof->queryEnd('invalid');
             $this->fail('Expected Zend_Db_Profiler_Exception not thrown');
         } catch (Zend_Db_Profiler_Exception $e) {
-            $this->assertContains('no query with handle', $e->getMessage());
+            $this->assertStringContainsString('no query with handle', $e->getMessage());
         }
     }
 
@@ -540,7 +540,7 @@ class Zend_Db_Profiler_StaticTest extends Zend_Db_TestSetup
             $prof->queryEnd($queryId);
             $this->fail('Expected Zend_Db_Profiler_Exception not thrown');
         } catch (Zend_Db_Profiler_Exception $e) {
-            $this->assertContains('has already ended', $e->getMessage());
+            $this->assertStringContainsString('has already ended', $e->getMessage());
         }
     }
 
@@ -608,7 +608,7 @@ class Zend_Db_Profiler_StaticTest extends Zend_Db_TestSetup
             $this->_db->getProfiler()->getQueryProfile('invalid');
             $this->fail('Expected Zend_Db_Profiler_Exception not thrown');
         } catch (Zend_Db_Profiler_Exception $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
     }
 

--- a/tests/Zend/Db/Profiler/TestCommon.php
+++ b/tests/Zend/Db/Profiler/TestCommon.php
@@ -42,13 +42,13 @@ require_once 'Zend/Db/TestSetup.php';
 abstract class Zend_Db_Profiler_TestCommon extends Zend_Db_TestSetup
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->_db->getProfiler()->setEnabled(true);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if($this->_db instanceof Zend_Db_Adapter_Abstract) {
             $this->_db->getProfiler()->setEnabled(false);
@@ -122,7 +122,7 @@ abstract class Zend_Db_Profiler_TestCommon extends Zend_Db_TestSetup
 
         // analyze query in the profile
         $sql = $qp->getQuery();
-        $this->assertContains(" = ?", $sql);
+        $this->assertStringContainsString(" = ?", $sql);
         $params = $qp->getQueryParams();
         $this->assertTrue(is_array($params));
         $this->assertEquals(array(1 => 2, 2 => 'VERIFIED'), $params);
@@ -144,7 +144,7 @@ abstract class Zend_Db_Profiler_TestCommon extends Zend_Db_TestSetup
 
         // analyze query in the profile
         $sql = $qp->getQuery();
-        $this->assertContains(" = ?", $sql);
+        $this->assertStringContainsString(" = ?", $sql);
         $params = $qp->getQueryParams();
         $this->assertTrue(is_array($params));
         $this->assertEquals(array(1 => 3, 2 => 'FIXED'), $params);
@@ -185,7 +185,7 @@ abstract class Zend_Db_Profiler_TestCommon extends Zend_Db_TestSetup
 
         // analyze query in the profile
         $sql = $qp->getQuery();
-        $this->assertContains(" = ?", $sql);
+        $this->assertStringContainsString(" = ?", $sql);
         $params = $qp->getQueryParams();
         $this->assertTrue(is_array($params));
         $this->assertEquals(array(1 => 2, 2 => 'VERIFIED'), $params);
@@ -207,7 +207,7 @@ abstract class Zend_Db_Profiler_TestCommon extends Zend_Db_TestSetup
 
         // analyze query in the profile
         $sql = $qp->getQuery();
-        $this->assertContains(" = ?", $sql);
+        $this->assertStringContainsString(" = ?", $sql);
         $params = $qp->getQueryParams();
         $this->assertTrue(is_array($params));
         $this->assertEquals(array(1 => 3, 2 => 'FIXED'), $params);

--- a/tests/Zend/Db/Select/TestCommon.php
+++ b/tests/Zend/Db/Select/TestCommon.php
@@ -1707,7 +1707,7 @@ abstract class Zend_Db_Select_TestCommon extends Zend_Db_TestSetup
         $colname = $this->_db->quoteIdentifier('colname');
 
         $s = $this->_db->select()->from('A')->joinUsing('B', $colname);
-        $this->assertContains("JOIN {$table_B} ON {$table_B}.{$colname} = {$table_A}.{$colname}", $s->assemble());
+        $this->assertStringContainsString("JOIN {$table_B} ON {$table_B}.{$colname} = {$table_A}.{$colname}", $s->assemble());
     }
 
     /**
@@ -1721,7 +1721,7 @@ abstract class Zend_Db_Select_TestCommon extends Zend_Db_TestSetup
         $colTwo  = $this->_db->quoteIdentifier('colTwo');
 
         $s = $this->_db->select()->from('A')->joinUsing('B', array($colOne,$colTwo));
-        $this->assertContains(
+        $this->assertStringContainsString(
             "JOIN {$table_B} ON {$table_B}.{$colOne} = {$table_A}.{$colOne}"
             . " AND {$table_B}.{$colTwo} = {$table_A}.{$colTwo}",
             $s->assemble()

--- a/tests/Zend/Db/Statement/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Statement/Pdo/MysqlTest.php
@@ -84,7 +84,7 @@ class Zend_Db_Statement_Pdo_MysqlTest extends Zend_Db_Statement_Pdo_TestCommon
             $stmt = $this->_db->query($sql);
         } catch (Zend_Db_Statement_Exception $e) {
             $message = $e->getMessage();
-            $this->assertContains($sql, $message);
+            $this->assertStringContainsString($sql, $message);
             return;
         }
         $this->fail('Expected exception');

--- a/tests/Zend/Db/Statement/TestCommon.php
+++ b/tests/Zend/Db/Statement/TestCommon.php
@@ -838,7 +838,7 @@ abstract class Zend_Db_Statement_TestCommon extends Zend_Db_TestSetup
         try {
             $stmt->setAttribute(1234, $value);
         } catch (Zend_Exception $e) {
-            $this->assertContains('This driver doesn\'t support setting attributes', $e->getMessage());
+            $this->assertStringContainsString('This driver doesn\'t support setting attributes', $e->getMessage());
         }
 
         try {

--- a/tests/Zend/Db/Table/Relationships/TestCommon.php
+++ b/tests/Zend/Db/Table/Relationships/TestCommon.php
@@ -166,7 +166,7 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
         $childRows = $table->fetchAll("$bug_id = 1");
         $childRow1 = $childRows->current();
 
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectException(\PHPUnit\Framework\Exception::class);
         $parentRow = $childRow1->findParentRow('nonexistant_class');
     }
 
@@ -267,7 +267,7 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
         $originRows = $table->find(1);
         $originRow1 = $originRows->current();
 
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectException(\PHPUnit\Framework\Exception::class);
         // Use nonexistant class for destination table
         $destRows = $originRow1->findManyToManyRowset('nonexistant_class', 'My_ZendDbTable_TableBugsProducts');
 
@@ -280,7 +280,7 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
         $originRows = $table->find(1);
         $originRow1 = $originRows->current();
 
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectException(\PHPUnit\Framework\Exception::class);
         // Use nonexistant class for intersection table
         $destRows = $originRow1->findManyToManyRowset('My_ZendDbTable_TableProducts', 'nonexistant_class');
     }
@@ -417,7 +417,7 @@ abstract class Zend_Db_Table_Relationships_TestCommon extends Zend_Db_Table_Test
         $parentRows = $table->find(1);
         $parentRow1 = $parentRows->current();
 
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectException(\PHPUnit\Framework\Exception::class);
         $childRows = $parentRow1->findDependentRowset('nonexistant_class');
     }
 

--- a/tests/Zend/Db/Table/Rowset/TestCommon.php
+++ b/tests/Zend/Db/Table/Rowset/TestCommon.php
@@ -276,7 +276,7 @@ abstract class Zend_Db_Table_Rowset_TestCommon extends Zend_Db_Table_TestSetup
             $this->fail();
         } catch (Exception $e) {
             $this->assertTrue($e instanceof Zend_Db_Table_Rowset_Exception);
-            $this->assertContains('Illegal index', $e->getMessage());
+            $this->assertStringContainsString('Illegal index', $e->getMessage());
         }
 
         $this->assertTrue($rowset[0] instanceof Zend_Db_Table_Row);
@@ -286,7 +286,7 @@ abstract class Zend_Db_Table_Rowset_TestCommon extends Zend_Db_Table_TestSetup
             $this->fail();
         } catch (Exception $e) {
             $this->assertTrue($e instanceof Zend_Db_Table_Rowset_Exception);
-            $this->assertContains('Illegal index', $e->getMessage());
+            $this->assertStringContainsString('Illegal index', $e->getMessage());
         }
         $this->assertEquals(0, $rowset->key());
     }

--- a/tests/Zend/Db/Table/Select/TestCommon.php
+++ b/tests/Zend/Db/Table/Select/TestCommon.php
@@ -47,7 +47,7 @@ abstract class Zend_Db_Table_Select_TestCommon extends Zend_Db_Select_TestCommon
      */
     protected $_table = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -57,7 +57,7 @@ abstract class Zend_Db_Table_Select_TestCommon extends Zend_Db_Select_TestCommon
         $this->_table['products']      = $this->_getTable('My_ZendDbTable_TableProducts');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->_runtimeIncludePath) {
             $this->_restoreIncludePath();
@@ -243,15 +243,15 @@ abstract class Zend_Db_Table_Select_TestCommon extends Zend_Db_Select_TestCommon
         $select3->setIntegrityCheck(false);
         $select3->joinLeft('tableB', 'tableA.id=tableB.id');
         $select3Text = $select3->__toString();
-        $this->assertNotContains('zfaccounts', $select3Text);
+        $this->assertStringNotContainsString('zfaccounts', $select3Text);
 
         $select4 = $table->select(Zend_Db_Table_Abstract::SELECT_WITH_FROM_PART);
         $select4->setIntegrityCheck(false);
         $select4->joinLeft('tableB', 'tableA.id=tableB.id');
         $select4Text = $select4->__toString();
-        $this->assertContains('zfaccounts', $select4Text);
-        $this->assertContains('tableA', $select4Text);
-        $this->assertContains('tableB', $select4Text);
+        $this->assertStringContainsString('zfaccounts', $select4Text);
+        $this->assertStringContainsString('tableA', $select4Text);
+        $this->assertStringContainsString('tableB', $select4Text);
     }
 
     public function testAssembleDbTableUnionSelect()

--- a/tests/Zend/Db/Table/TestCommon.php
+++ b/tests/Zend/Db/Table/TestCommon.php
@@ -469,8 +469,8 @@ abstract class Zend_Db_Table_TestCommon extends Zend_Db_Table_TestSetup
         } catch (Zend_Exception $e) {
             $this->assertTrue($e instanceof Zend_Db_Table_Exception,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
-            $this->assertContains("Primary key column(s)", $e->getMessage());
-            $this->assertContains("are not columns in this table", $e->getMessage());
+            $this->assertStringContainsString("Primary key column(s)", $e->getMessage());
+            $this->assertStringContainsString("are not columns in this table", $e->getMessage());
         }
     }
 
@@ -483,8 +483,8 @@ abstract class Zend_Db_Table_TestCommon extends Zend_Db_Table_TestSetup
         } catch (Zend_Exception $e) {
             $this->assertTrue($e instanceof Zend_Db_Table_Exception,
                 'Expecting object of type Zend_Db_Table_Exception, got '.get_class($e));
-            $this->assertContains("Primary key column(s)", $e->getMessage());
-            $this->assertContains("are not columns in this table", $e->getMessage());
+            $this->assertStringContainsString("Primary key column(s)", $e->getMessage());
+            $this->assertStringContainsString("are not columns in this table", $e->getMessage());
         }
     }
 
@@ -724,7 +724,7 @@ abstract class Zend_Db_Table_TestCommon extends Zend_Db_Table_TestSetup
 
         $qp = $this->_db->getProfiler()->getLastQueryProfile();
         $tableSpec = $this->_db->quoteIdentifier($identifier, true);
-        $this->assertContains("INSERT INTO $tableSpec ", $qp->getQuery());
+        $this->assertStringContainsString("INSERT INTO $tableSpec ", $qp->getQuery());
     }
 
     public function testTableInsertSequence()
@@ -933,7 +933,7 @@ abstract class Zend_Db_Table_TestCommon extends Zend_Db_Table_TestSetup
         $this->assertEquals(1, $result);
         $qp = $this->_db->getProfiler()->getLastQueryProfile();
         $tableSpec = $this->_db->quoteIdentifier($identifier, true);
-        $this->assertContains("UPDATE $tableSpec ", $qp->getQuery());
+        $this->assertStringContainsString("UPDATE $tableSpec ", $qp->getQuery());
     }
 
     public function testTableUpdateWhereArray()
@@ -993,7 +993,7 @@ abstract class Zend_Db_Table_TestCommon extends Zend_Db_Table_TestSetup
 
         $qp = $this->_db->getProfiler()->getLastQueryProfile();
         $tableSpec = $this->_db->quoteIdentifier($identifier, true);
-        $this->assertContains("DELETE FROM $tableSpec ", $qp->getQuery());
+        $this->assertStringContainsString("DELETE FROM $tableSpec ", $qp->getQuery());
     }
 
     public function testTableDeleteWhereArray()

--- a/tests/Zend/Db/Table/TestSetup.php
+++ b/tests/Zend/Db/Table/TestSetup.php
@@ -49,7 +49,7 @@ abstract class Zend_Db_Table_TestSetup extends Zend_Db_TestSetup
 
     protected $_runtimeIncludePath = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -59,7 +59,7 @@ abstract class Zend_Db_Table_TestSetup extends Zend_Db_TestSetup
         $this->_table['products']      = $this->_getTable('My_ZendDbTable_TableProducts');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->_runtimeIncludePath) {
             $this->_restoreIncludePath();

--- a/tests/Zend/Db/TestSetup.php
+++ b/tests/Zend/Db/TestSetup.php
@@ -57,7 +57,7 @@ abstract class Zend_Db_TestSetup extends \PHPUnit\Framework\TestCase
      * Subclasses should call parent::setUp() before
      * doing their own logic, e.g. creating metadata.
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_setUpTestUtil();
         $this->_setUpAdapter();
@@ -87,7 +87,7 @@ abstract class Zend_Db_TestSetup extends \PHPUnit\Framework\TestCase
      * Subclasses should call parent::tearDown() after
      * doing their own logic, e.g. deleting metadata.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->_util->tearDown();
         $this->_db->closeConnection();

--- a/tests/Zend/Db/TestUtil/Common.php
+++ b/tests/Zend/Db/TestUtil/Common.php
@@ -530,7 +530,7 @@ abstract class Zend_Db_TestUtil_Common
         return $this->_db;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->dropView();
         $this->dropTable();

--- a/tests/Zend/Db/TestUtil/Mysqli.php
+++ b/tests/Zend/Db/TestUtil/Mysqli.php
@@ -125,7 +125,7 @@ class Zend_Db_TestUtil_Mysqli extends Zend_Db_TestUtil_Common
         $this->_createTestProcedure();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->_dropTestProcedure();
 

--- a/tests/Zend/ExceptionTest.php
+++ b/tests/Zend/ExceptionTest.php
@@ -64,8 +64,8 @@ class Zend_ExceptionTest extends \PHPUnit\Framework\TestCase
         $p = new Zend_Exception('p', 0);
         $e = new Zend_Exception('e', 0, $p);
         $s = $e->__toString();
-        $this->assertContains('p', $s);
-        $this->assertContains('Next', $s);
-        $this->assertContains('e', $s);
+        $this->assertStringContainsString('p', $s);
+        $this->assertStringContainsString('Next', $s);
+        $this->assertStringContainsString('e', $s);
     }
 }

--- a/tests/Zend/File/Transfer/Adapter/AbstractTest.php
+++ b/tests/Zend/File/Transfer/Adapter/AbstractTest.php
@@ -51,7 +51,7 @@ class Zend_File_Transfer_Adapter_AbstractTest extends \PHPUnit\Framework\TestCas
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->adapter = new Zend_File_Transfer_Adapter_AbstractTest_MockAdapter();
     }
@@ -62,7 +62,7 @@ class Zend_File_Transfer_Adapter_AbstractTest extends \PHPUnit\Framework\TestCas
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
@@ -647,7 +647,7 @@ class Zend_File_Transfer_Adapter_AbstractTest extends \PHPUnit\Framework\TestCas
             $this->adapter->getHash('foo', 'unknown_hash');
             $this->fail();
         } catch (Zend_Exception $e) {
-            $this->assertContains('Unknown hash algorithm', $e->getMessage());
+            $this->assertStringContainsString('Unknown hash algorithm', $e->getMessage());
         }
     }
 
@@ -684,7 +684,7 @@ class Zend_File_Transfer_Adapter_AbstractTest extends \PHPUnit\Framework\TestCas
             $this->assertEquals(10, $this->adapter->getFileSize());
             $this->fail();
         } catch (Zend_File_Transfer_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
     }
 
@@ -712,7 +712,7 @@ class Zend_File_Transfer_Adapter_AbstractTest extends \PHPUnit\Framework\TestCas
             $this->assertEquals('image/jpeg', $this->adapter->getMimeType());
             $this->fail();
         } catch (Zend_File_Transfer_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
     }
 
@@ -739,7 +739,7 @@ class Zend_File_Transfer_Adapter_AbstractTest extends \PHPUnit\Framework\TestCas
             $this->assertEquals('image/jpeg', $this->adapter->getMimeType());
             $this->fail();
         } catch (Zend_File_Transfer_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
     }
 
@@ -752,7 +752,7 @@ class Zend_File_Transfer_Adapter_AbstractTest extends \PHPUnit\Framework\TestCas
             $this->assertTrue(is_string($this->adapter->getDestination('reallynonexisting')));
             $this->fail();
         } catch(Exception $e) {
-            $this->assertContains('not find', $e->getMessage());
+            $this->assertStringContainsString('not find', $e->getMessage());
         }
     }
 

--- a/tests/Zend/File/Transfer/Adapter/HttpTest.php
+++ b/tests/Zend/File/Transfer/Adapter/HttpTest.php
@@ -46,7 +46,7 @@ class Zend_File_Transfer_Adapter_HttpTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $_FILES = array(
             'txt' => array(
@@ -64,14 +64,14 @@ class Zend_File_Transfer_Adapter_HttpTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
     public function testEmptyAdapter()
     {
         $files = $this->adapter->getFileName();
-        $this->assertContains('test.txt', $files);
+        $this->assertStringContainsString('test.txt', $files);
     }
 
     public function testAutoSetUploadValidator()
@@ -124,7 +124,7 @@ class Zend_File_Transfer_Adapter_HttpTest extends \PHPUnit\Framework\TestCase
         try {
             $this->assertFalse($this->adapter->receive('unknownFile'));
         } catch (Zend_File_Transfer_Exception $e) {
-            $this->assertContains('not find', $e->getMessage());
+            $this->assertStringContainsString('not find', $e->getMessage());
         }
     }
 
@@ -215,7 +215,7 @@ class Zend_File_Transfer_Adapter_HttpTest extends \PHPUnit\Framework\TestCase
         $_FILES = array();
         $adapter = new Zend_File_Transfer_Adapter_HttpTest_MockAdapter();
         $this->assertFalse($adapter->isValidParent());
-        $this->assertContains('exceeds the defined ini size', current($adapter->getMessages()));
+        $this->assertStringContainsString('exceeds the defined ini size', current($adapter->getMessages()));
     }
 }
 

--- a/tests/Zend/Layout/FunctionalTest.php
+++ b/tests/Zend/Layout/FunctionalTest.php
@@ -34,7 +34,7 @@ require_once 'Zend/Controller/Plugin/ErrorHandler.php';
  */
 class Zend_Layout_FunctionalTest extends Zend_Test_PHPUnit_ControllerTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->bootstrap = array($this, 'appBootstrap');
         parent::setUp();

--- a/tests/Zend/Layout/HelperTest.php
+++ b/tests/Zend/Layout/HelperTest.php
@@ -43,7 +43,7 @@ class Zend_Layout_HelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Layout_HelperTest_Layout::resetMvcInstance();
         Zend_Controller_Front::getInstance()->resetInstance();
@@ -61,7 +61,7 @@ class Zend_Layout_HelperTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 

--- a/tests/Zend/Layout/LayoutTest.php
+++ b/tests/Zend/Layout/LayoutTest.php
@@ -47,7 +47,7 @@ class Zend_Layout_LayoutTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Layout_LayoutTest_Override::resetMvcInstance();
 
@@ -66,7 +66,7 @@ class Zend_Layout_LayoutTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Layout::resetMvcInstance();
     }
@@ -375,8 +375,8 @@ class Zend_Layout_LayoutTest extends \PHPUnit\Framework\TestCase
                ->setView($view);
         $layout->message = 'Rendered layout';
         $received = $layout->render();
-        $this->assertContains('Testing layouts:', $received);
-        $this->assertContains($layout->message, $received);
+        $this->assertStringContainsString('Testing layouts:', $received);
+        $this->assertStringContainsString($layout->message, $received);
     }
 
     public function testRenderWithDefaultInflection()
@@ -387,8 +387,8 @@ class Zend_Layout_LayoutTest extends \PHPUnit\Framework\TestCase
                ->setView($view);
         $layout->message = 'Rendered layout';
         $received = $layout->render();
-        $this->assertContains('Testing layouts:', $received);
-        $this->assertContains($layout->message, $received);
+        $this->assertStringContainsString('Testing layouts:', $received);
+        $this->assertStringContainsString($layout->message, $received);
     }
 
     public function testRenderWithCustomInflection()
@@ -402,8 +402,8 @@ class Zend_Layout_LayoutTest extends \PHPUnit\Framework\TestCase
                   ->setStaticRule('suffix', 'php');
         $layout->message = 'Rendered layout';
         $received = $layout->render();
-        $this->assertContains('Testing layouts with custom inflection:', $received);
-        $this->assertContains($layout->message, $received);
+        $this->assertStringContainsString('Testing layouts with custom inflection:', $received);
+        $this->assertStringContainsString($layout->message, $received);
     }
 
     public function testGetMvcInstanceReturnsNullWhenStartMvcHasNotBeenCalled()

--- a/tests/Zend/Layout/PluginTest.php
+++ b/tests/Zend/Layout/PluginTest.php
@@ -45,7 +45,7 @@ class Zend_Layout_PluginTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Controller_Front::getInstance()->resetInstance();
 
@@ -65,7 +65,7 @@ class Zend_Layout_PluginTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Layout::resetMvcInstance();
     }
@@ -126,8 +126,8 @@ class Zend_Layout_PluginTest extends \PHPUnit\Framework\TestCase
         $plugin->postDispatch($request);
 
         $body = $response->getBody();
-        $this->assertContains('Application content', $body, $body);
-        $this->assertContains('Site Layout', $body, $body);
+        $this->assertStringContainsString('Application content', $body, $body);
+        $this->assertStringContainsString('Site Layout', $body, $body);
     }
 
     public function testPostDispatchDoesNotRenderLayoutWhenForwardDetected()
@@ -151,8 +151,8 @@ class Zend_Layout_PluginTest extends \PHPUnit\Framework\TestCase
         $plugin->postDispatch($request);
 
         $body = $response->getBody();
-        $this->assertContains('Application content', $body);
-        $this->assertNotContains('Site Layout', $body);
+        $this->assertStringContainsString('Application content', $body);
+        $this->assertStringNotContainsString('Site Layout', $body);
     }
 
     public function testPostDispatchDoesNotRenderLayoutWhenLayoutDisabled()
@@ -177,8 +177,8 @@ class Zend_Layout_PluginTest extends \PHPUnit\Framework\TestCase
         $plugin->postDispatch($request);
 
         $body = $response->getBody();
-        $this->assertContains('Application content', $body);
-        $this->assertNotContains('Site Layout', $body);
+        $this->assertStringContainsString('Application content', $body);
+        $this->assertStringNotContainsString('Site Layout', $body);
     }
 
     /**
@@ -207,8 +207,8 @@ class Zend_Layout_PluginTest extends \PHPUnit\Framework\TestCase
         $plugin->postDispatch($request);
 
         $body = $response->getBody();
-        $this->assertContains('Application content', $body);
-        $this->assertNotContains('Site Layout', $body);
+        $this->assertStringContainsString('Application content', $body);
+        $this->assertStringNotContainsString('Site Layout', $body);
     }
 }
 

--- a/tests/Zend/Loader/Autoloader/ResourceTest.php
+++ b/tests/Zend/Loader/Autoloader/ResourceTest.php
@@ -48,7 +48,7 @@ require_once 'Zend/Config.php';
  */
 class Zend_Loader_Autoloader_ResourceTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -73,7 +73,7 @@ class Zend_Loader_Autoloader_ResourceTest extends \PHPUnit\Framework\TestCase
         ));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();
@@ -151,7 +151,7 @@ class Zend_Loader_Autoloader_ResourceTest extends \PHPUnit\Framework\TestCase
         $resources = $this->loader->getResourceTypes();
         $this->assertTrue(array_key_exists('models', $resources));
         $this->assertEquals($this->loader->getNamespace() . '_Model', $resources['models']['namespace']);
-        $this->assertContains('/models', $resources['models']['path']);
+        $this->assertStringContainsString('/models', $resources['models']['path']);
     }
 
     public function testAutoloaderShouldAllowAddingResettingResourcePaths()
@@ -159,8 +159,8 @@ class Zend_Loader_Autoloader_ResourceTest extends \PHPUnit\Framework\TestCase
         $this->loader->addResourceType('models', 'models', 'Model');
         $this->loader->addResourceType('models', 'apis');
         $resources = $this->loader->getResourceTypes();
-        $this->assertNotContains('/models', $resources['models']['path']);
-        $this->assertContains('/apis', $resources['models']['path']);
+        $this->assertStringNotContainsString('/models', $resources['models']['path']);
+        $this->assertStringContainsString('/apis', $resources['models']['path']);
     }
 
     public function testAutoloaderShouldSupportAddingMultipleResourceTypesAtOnce()

--- a/tests/Zend/Loader/AutoloaderFactoryClassMapLoaderTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryClassMapLoaderTest.php
@@ -41,7 +41,7 @@ class Zend_Loader_AutoloaderFactoryClassMapLoaderTest extends \PHPUnit\Framework
      */
     protected $_includePath;
 
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->_loaders = spl_autoload_functions();
@@ -61,7 +61,7 @@ class Zend_Loader_AutoloaderFactoryClassMapLoaderTest extends \PHPUnit\Framework
         $this->_includePath = get_include_path();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Loader_AutoloaderFactory::unregisterAutoloaders();
         // Restore original autoloaders

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -36,7 +36,7 @@ require_once 'Zend/Loader/StandardAutoloader.php';
  */
 class Zend_Loader_AutoloaderFactoryTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -63,7 +63,7 @@ class Zend_Loader_AutoloaderFactoryTest extends \PHPUnit\Framework\TestCase
         $this->includePath = get_include_path();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Loader_AutoloaderFactory::unregisterAutoloaders();
         // Restore original autoloaders

--- a/tests/Zend/Loader/AutoloaderTest.php
+++ b/tests/Zend/Loader/AutoloaderTest.php
@@ -40,7 +40,7 @@ require_once 'Zend/Loader/Autoloader/Interface.php';
  */
 class Zend_Loader_AutoloaderTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -60,7 +60,7 @@ class Zend_Loader_AutoloaderTest extends \PHPUnit\Framework\TestCase
         $this->error = null;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();

--- a/tests/Zend/Loader/ClassMapAutoloaderTest.php
+++ b/tests/Zend/Loader/ClassMapAutoloaderTest.php
@@ -32,7 +32,7 @@ require_once 'Zend/Loader/ClassMapAutoloader.php';
  */
 class Zend_Loader_ClassMapAutoloaderTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -48,7 +48,7 @@ class Zend_Loader_ClassMapAutoloaderTest extends \PHPUnit\Framework\TestCase
         $this->loader = new Zend_Loader_ClassMapAutoloader();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();
@@ -149,7 +149,7 @@ class Zend_Loader_ClassMapAutoloaderTest extends \PHPUnit\Framework\TestCase
                 $this->loader->registerAutoloadMaps($test);
                 $this->fail('Should not register non-traversable arguments');
             } catch (Zend_Loader_Exception_InvalidArgumentException $e) {
-                $this->assertContains('array or implement Traversable', $e->getMessage());
+                $this->assertStringContainsString('array or implement Traversable', $e->getMessage());
             }
         }
     }

--- a/tests/Zend/Loader/PluginLoaderTest.php
+++ b/tests/Zend/Loader/PluginLoaderTest.php
@@ -42,7 +42,7 @@ class Zend_Loader_PluginLoaderTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         if (file_exists($this->_includeCache)) {
             unlink($this->_includeCache);
@@ -59,7 +59,7 @@ class Zend_Loader_PluginLoaderTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->clearStaticPaths();
         Zend_Loader_PluginLoader::setIncludeFileCache(null);
@@ -418,7 +418,7 @@ class Zend_Loader_PluginLoaderTest extends \PHPUnit\Framework\TestCase
         }
         $this->assertTrue(file_exists($cacheFile));
         $cache = file_get_contents($cacheFile);
-        $this->assertContains('CacheTest.php', $cache);
+        $this->assertStringContainsString('CacheTest.php', $cache);
     }
 
     /**
@@ -456,7 +456,7 @@ class Zend_Loader_PluginLoaderTest extends \PHPUnit\Framework\TestCase
         }
 
         $classPath = $loader->getClassPath('DeclareVars');
-        $this->assertContains($expected, $classPath);
+        $this->assertStringContainsString($expected, $classPath);
     }
 
     /**
@@ -487,7 +487,7 @@ class Zend_Loader_PluginLoaderTest extends \PHPUnit\Framework\TestCase
             $this->fail();
         } catch (Exception $e) {
             $this->assertTrue($e instanceof Zend_Loader_PluginLoader_Exception);
-            $this->assertContains('Prefix My_Namespace_ / Path ZF9721', $e->getMessage());
+            $this->assertStringContainsString('Prefix My_Namespace_ / Path ZF9721', $e->getMessage());
         }
         $this->assertEquals(1, count($loader->getPaths('My_Namespace_')));
     }

--- a/tests/Zend/Loader/StandardAutoloaderTest.php
+++ b/tests/Zend/Loader/StandardAutoloaderTest.php
@@ -33,7 +33,7 @@ require_once 'Zend/Loader/TestAsset/StandardAutoloader.php';
  */
 class Zend_Loader_StandardAutoloaderTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -47,7 +47,7 @@ class Zend_Loader_StandardAutoloaderTest extends \PHPUnit\Framework\TestCase
         $this->includePath = get_include_path();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Restore original autoloaders
         $loaders = spl_autoload_functions();
@@ -90,7 +90,7 @@ class Zend_Loader_StandardAutoloaderTest extends \PHPUnit\Framework\TestCase
                 $loader->setOptions(true);
                 $this->fail('Setting options with invalid type should fail');
             } catch (Zend_Loader_Exception_InvalidArgumentException $e) {
-                $this->assertContains('array or Traversable', $e->getMessage());
+                $this->assertStringContainsString('array or Traversable', $e->getMessage());
             }
         }
     }
@@ -193,7 +193,7 @@ class Zend_Loader_StandardAutoloaderTest extends \PHPUnit\Framework\TestCase
     {
         $loader = new Zend_Loader_StandardAutoloader();
         $expected = array();
-        $this->assertAttributeEquals($expected, 'prefixes', $loader);
+        $this->assertEquals($expected, $loader->getPrefixes());
     }
 
     public function testCanTellAutoloaderToRegisterZfPrefixAtInstantiation()
@@ -202,6 +202,6 @@ class Zend_Loader_StandardAutoloaderTest extends \PHPUnit\Framework\TestCase
         $r      = new ReflectionClass($loader);
         $file   = $r->getFileName();
         $expected = array('Zend_' => dirname(dirname($file)) . DIRECTORY_SEPARATOR);
-        $this->assertAttributeEquals($expected, 'prefixes', $loader);
+        $this->assertEquals($expected, $loader->getPrefixes());
     }
 }

--- a/tests/Zend/LoaderTest.php
+++ b/tests/Zend/LoaderTest.php
@@ -41,7 +41,7 @@ require_once 'Zend/Loader/Autoloader.php';
 class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         // Store original autoloaders
         $this->loaders = spl_autoload_functions();
@@ -59,7 +59,7 @@ class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
         Zend_Loader_Autoloader::resetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->errorHandler !== null) {
             restore_error_handler();
@@ -244,10 +244,10 @@ class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
     {
         $this->setErrorHandler();
         $this->assertEquals('Zend_Db_Profiler_Exception', Zend_Loader::autoload('Zend_Db_Profiler_Exception'));
-        $this->assertContains('deprecated', $this->error);
+        $this->assertStringContainsString('deprecated', $this->error);
         $this->error = null;
         $this->assertEquals('Zend_Auth_Storage_Interface', Zend_Loader::autoload('Zend_Auth_Storage_Interface'));
-        $this->assertContains('deprecated', $this->error);
+        $this->assertStringContainsString('deprecated', $this->error);
     }
 
     /**
@@ -257,7 +257,7 @@ class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
     {
         $this->setErrorHandler();
         $this->assertFalse(Zend_Loader::autoload('Zend_FooBar_Magic_Abstract'));
-        $this->assertContains('deprecated', $this->error);
+        $this->assertStringContainsString('deprecated', $this->error);
     }
 
     public function testLoaderRegisterAutoloadRegisters()
@@ -268,7 +268,7 @@ class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
 
         $this->setErrorHandler();
         Zend_Loader::registerAutoload();
-        $this->assertContains('deprecated', $this->error);
+        $this->assertStringContainsString('deprecated', $this->error);
 
         $autoloaders = spl_autoload_functions();
         $found       = false;
@@ -293,7 +293,7 @@ class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
 
         $this->setErrorHandler();
         Zend_Loader::registerAutoload('Zend_Loader_MyLoader');
-        $this->assertContains('deprecated', $this->error);
+        $this->assertStringContainsString('deprecated', $this->error);
 
         $autoloaders = spl_autoload_functions();
         $expected    = array('Zend_Loader_MyLoader', 'autoload');
@@ -317,7 +317,7 @@ class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
 
         $this->setErrorHandler();
         Zend_Loader::registerAutoload('Zend_Loader_MyOverloader');
-        $this->assertContains('deprecated', $this->error);
+        $this->assertStringContainsString('deprecated', $this->error);
 
         $autoloaders = spl_autoload_functions();
         $found       = false;
@@ -363,7 +363,7 @@ class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
             $this->fail('registerAutoload should fail without spl_autoload');
         } catch (Zend_Exception $e) {
             $this->assertEquals('The class "stdClass" does not have an autoload() method', $e->getMessage());
-            $this->assertContains('deprecated', $this->error);
+            $this->assertStringContainsString('deprecated', $this->error);
         }
     }
 
@@ -375,7 +375,7 @@ class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
 
         $this->setErrorHandler();
         Zend_Loader::registerAutoload('Zend_Loader_MyOverloader');
-        $this->assertContains('deprecated', $this->error);
+        $this->assertStringContainsString('deprecated', $this->error);
 
         $expected    = array('Zend_Loader_MyOverloader', 'autoload');
         $autoloaders = Zend_Loader_Autoloader::getInstance()->getAutoloaders();
@@ -407,7 +407,7 @@ class Zend_LoaderTest extends \PHPUnit\Framework\TestCase
 
         $this->setErrorHandler();
         Zend_Loader::registerAutoload();
-        $this->assertContains('deprecated', $this->error);
+        $this->assertStringContainsString('deprecated', $this->error);
 
         $autoloader = Zend_Loader_Autoloader::getInstance();
         $this->assertTrue($autoloader->isFallbackAutoloader());

--- a/tests/Zend/Locale/DataTest.php
+++ b/tests/Zend/Locale/DataTest.php
@@ -39,7 +39,7 @@ class Zend_Locale_DataTest extends \PHPUnit\Framework\TestCase
 
     private $_cache = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         require_once 'Zend/Cache.php';
         $this->_cache = Zend_Cache::factory('Core', 'File',
@@ -49,7 +49,7 @@ class Zend_Locale_DataTest extends \PHPUnit\Framework\TestCase
     }
 
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->_cache->clean(Zend_Cache::CLEANING_MODE_ALL);
     }

--- a/tests/Zend/Locale/FormatTest.php
+++ b/tests/Zend/Locale/FormatTest.php
@@ -38,7 +38,7 @@ class Zend_Locale_FormatTest extends \PHPUnit\Framework\TestCase
     /**
      * teardown / cleanup
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         // if the setlocale option is enabled, then don't change the setlocale below
         if (defined('TESTS_ZEND_LOCALE_FORMAT_SETLOCALE') && TESTS_ZEND_LOCALE_FORMAT_SETLOCALE === false) {

--- a/tests/Zend/Locale/MathTest.php
+++ b/tests/Zend/Locale/MathTest.php
@@ -42,7 +42,7 @@ class Zend_Locale_MathTest extends \PHPUnit\Framework\TestCase
     /**
      * setup for tests (BCMath is not designed to normalize localized numbers)
      */
-    public function setUp()
+    public function setUp(): void
     {
         self::$savedLocale = setlocale(LC_NUMERIC, '0');
         if (self::$savedLocale != 'C') {
@@ -53,7 +53,7 @@ class Zend_Locale_MathTest extends \PHPUnit\Framework\TestCase
     /**
      * teardown for tests (restore whatever setlocale was previously in place)
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if (self::$savedLocale != 'C') {
             setlocale(LC_NUMERIC, self::$savedLocale);
@@ -79,14 +79,14 @@ class Zend_Locale_MathTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(        round(3.6), Zend_Locale_Math::round('3.6'));
         $this->assertEquals(               '4', Zend_Locale_Math::round('3.6', 0));
         $this->assertEquals(      round(3.6,0), Zend_Locale_Math::round('3.6', 0));
-        $this->assertEquals(            '1.96', Zend_Locale_Math::round('1.95583', 2), '', 0.02);
-        $this->assertEquals(  round(1.95583,2), Zend_Locale_Math::round('1.95583', 2), '', 0.02);
-        $this->assertEquals(           1242000, Zend_Locale_Math::round('1241757', -3), '', 250);
-        $this->assertEquals(round(1241757, -3), Zend_Locale_Math::round('1241757', -3), '', 250);
-        $this->assertEquals(              5.05, Zend_Locale_Math::round('5.045', 2), '', 0.02);
-        $this->assertEquals(   round(5.045, 2), Zend_Locale_Math::round('5.045', 2), '', 0.02);
-        $this->assertEquals(              5.06, Zend_Locale_Math::round('5.055', 2), '', 0.02);
-        $this->assertEquals(   round(5.055, 2), Zend_Locale_Math::round('5.055', 2), '', 0.02);
+        $this->assertEqualsWithDelta(            '1.96', Zend_Locale_Math::round('1.95583', 2), 0.02);
+        $this->assertEqualsWithDelta(  round(1.95583,2), Zend_Locale_Math::round('1.95583', 2), 0.02);
+        $this->assertEqualsWithDelta(           1242000, Zend_Locale_Math::round('1241757', -3), 250);
+        $this->assertEqualsWithDelta(round(1241757, -3), Zend_Locale_Math::round('1241757', -3), 250);
+        $this->assertEqualsWithDelta(              5.05, Zend_Locale_Math::round('5.045', 2), 0.02);
+        $this->assertEqualsWithDelta(   round(5.045, 2), Zend_Locale_Math::round('5.045', 2), 0.02);
+        $this->assertEqualsWithDelta(              5.06, Zend_Locale_Math::round('5.055', 2), 0.02);
+        $this->assertEqualsWithDelta(   round(5.055, 2), Zend_Locale_Math::round('5.055', 2), 0.02);
     }
 
     /**
@@ -1585,13 +1585,13 @@ class Zend_Locale_MathTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(        round(-3.6), Zend_Locale_Math::round('-3.6'));
         $this->assertEquals(               '-4', Zend_Locale_Math::round('-3.6', 0));
         $this->assertEquals(      round(-3.6,0), Zend_Locale_Math::round('-3.6', 0));
-        $this->assertEquals(            '-1.96', Zend_Locale_Math::round('-1.95583', 2), '', 0.02);
-        $this->assertEquals(  round(-1.95583,2), Zend_Locale_Math::round('-1.95583', 2), '', 0.02);
-        $this->assertEquals(           -1242000, Zend_Locale_Math::round('-1241757', -3), '', 250);
-        $this->assertEquals(round(-1241757, -3), Zend_Locale_Math::round('-1241757', -3), '', 250);
-        $this->assertEquals(              -5.05, Zend_Locale_Math::round('-5.045', 2), '', 0.02);
-        $this->assertEquals(   round(-5.045, 2), Zend_Locale_Math::round('-5.045', 2), '', 0.02);
-        $this->assertEquals(              -5.06, Zend_Locale_Math::round('-5.055', 2), '', 0.02);
-        $this->assertEquals(   round(-5.055, 2), Zend_Locale_Math::round('-5.055', 2), '', 0.02);
+        $this->assertEqualsWithDelta(            '-1.96', Zend_Locale_Math::round('-1.95583', 2), 0.02);
+        $this->assertEqualsWithDelta(  round(-1.95583,2), Zend_Locale_Math::round('-1.95583', 2), 0.02);
+        $this->assertEqualsWithDelta(           -1242000, Zend_Locale_Math::round('-1241757', -3), 250);
+        $this->assertEqualsWithDelta(round(-1241757, -3), Zend_Locale_Math::round('-1241757', -3), 250);
+        $this->assertEqualsWithDelta(              -5.05, Zend_Locale_Math::round('-5.045', 2), 0.02);
+        $this->assertEqualsWithDelta(   round(-5.045, 2), Zend_Locale_Math::round('-5.045', 2), 0.02);
+        $this->assertEqualsWithDelta(              -5.06, Zend_Locale_Math::round('-5.055', 2), 0.02);
+        $this->assertEqualsWithDelta(   round(-5.055, 2), Zend_Locale_Math::round('-5.055', 2), 0.02);
     }
 }

--- a/tests/Zend/LocaleTest.php
+++ b/tests/Zend/LocaleTest.php
@@ -41,7 +41,7 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
     private $_cache  = null;
     private $_locale = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_locale = setlocale(LC_ALL, 0);
         setlocale(LC_ALL, 'de');
@@ -57,7 +57,7 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
         putenv("HTTP_ACCEPT_LANGUAGE=,de,en-UK-US;q=0.5,fr_FR;q=0.2");
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->_cache->clean(Zend_Cache::CLEANING_MODE_ALL);
         if (is_string($this->_locale) && strpos($this->_locale, ';')) {
@@ -127,14 +127,14 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
             $this->assertTrue($locale instanceof Zend_Locale);
         } catch (Zend_Locale_Exception $e) {
             // ignore environments where the locale can not be detected
-            $this->assertContains('Autodetection', $e->getMessage());
+            $this->assertStringContainsString('Autodetection', $e->getMessage());
         }
 
         try {
             $this->assertTrue(new Zend_LocaleTestHelper(Zend_Locale::BROWSER) instanceof Zend_Locale);
         } catch (Zend_Locale_Exception $e) {
             // ignore environments where the locale can not be detected
-            $this->assertContains('Autodetection', $e->getMessage());
+            $this->assertStringContainsString('Autodetection', $e->getMessage());
         }
 
         $locale = new Zend_LocaleTestHelper('de');
@@ -272,7 +272,7 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
             $this->assertTrue(is_string($value->toString()));
         } catch (Zend_Locale_Exception $e) {
             // ignore environments where the locale can not be detected
-            $this->assertContains('Autodetection', $e->getMessage());
+            $this->assertStringContainsString('Autodetection', $e->getMessage());
         }
 
         try {
@@ -280,7 +280,7 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
             $this->assertTrue(is_string($value->toString()));
         } catch (Zend_Locale_Exception $e) {
             // ignore environments where the locale can not be detected
-            $this->assertContains('Autodetection', $e->getMessage());
+            $this->assertStringContainsString('Autodetection', $e->getMessage());
         }
     }
 
@@ -407,7 +407,7 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
             $temp = Zend_LocaleTestHelper::getTranslation('xx');
             $this->fail();
         } catch (Zend_Locale_Exception $e) {
-            $this->assertContains('Unknown detail (', $e->getMessage());
+            $this->assertStringContainsString('Unknown detail (', $e->getMessage());
         }
 
         $this->assertEquals('Deutsch', Zend_LocaleTestHelper::getTranslation('de', 'language', 'de_DE'));
@@ -500,7 +500,7 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
             $temp = Zend_LocaleTestHelper::getTranslationList();
             $this->fail();
         } catch (Zend_Locale_Exception $e) {
-            $this->assertContains('Unknown list (', $e->getMessage());
+            $this->assertStringContainsString('Unknown list (', $e->getMessage());
         }
 
         $this->assertTrue(in_array('Deutsch', Zend_LocaleTestHelper::getTranslationList('language', 'de_DE')));
@@ -606,13 +606,13 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
         try {
             $this->assertTrue(is_array(Zend_LocaleTestHelper::getQuestion('browser')));
         } catch (Zend_Locale_Exception $e) {
-            $this->assertContains('Autodetection', $e->getMessage());
+            $this->assertStringContainsString('Autodetection', $e->getMessage());
         }
 
         try {
             $this->assertTrue(is_array(Zend_LocaleTestHelper::getQuestion('environment')));
         } catch (Zend_Locale_Exception $e) {
-            $this->assertContains('ocale', $e->getMessage());
+            $this->assertStringContainsString('ocale', $e->getMessage());
         }
     }
 
@@ -717,7 +717,7 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
             Zend_LocaleTestHelper::setDefault('auto');
             $this->fail();
         } catch (Zend_Locale_Exception $e) {
-            $this->assertContains("full qualified locale", $e->getMessage());
+            $this->assertStringContainsString("full qualified locale", $e->getMessage());
         }
 
         try {
@@ -732,14 +732,14 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
             Zend_LocaleTestHelper::setDefault('xy_ZZ');
             $this->fail();
         } catch (Zend_Locale_Exception $e) {
-            $this->assertContains("Unknown locale", $e->getMessage());
+            $this->assertStringContainsString("Unknown locale", $e->getMessage());
         }
 
         try {
             Zend_LocaleTestHelper::setDefault('de', 101);
             $this->fail();
         } catch (Zend_Locale_Exception $e) {
-            $this->assertContains("Quality must be between", $e->getMessage());
+            $this->assertStringContainsString("Quality must be between", $e->getMessage());
         }
 
         try {
@@ -802,7 +802,7 @@ class Zend_LocaleTest extends \PHPUnit\Framework\TestCase
             $locale = Zend_LocaleTestHelper::findLocale('xx_YY');
             $this->fail();
         } catch (Zend_Locale_Exception $e) {
-            $this->assertContains('is no known locale', $e->getMessage());
+            $this->assertStringContainsString('is no known locale', $e->getMessage());
         }
 
         Zend_Registry::set('Zend_Locale', 'de');

--- a/tests/Zend/Measure/TemperatureTest.php
+++ b/tests/Zend/Measure/TemperatureTest.php
@@ -40,7 +40,7 @@ require_once 'Zend/Registry.php';
  */
 class Zend_Measure_TemperatureTest extends \PHPUnit\Framework\TestCase
 {
-    public function setup()
+    public function setup(): void
     {
         if (Zend_Registry::isRegistered('Zend_Locale')) {
             $registry = Zend_Registry::getInstance();
@@ -52,7 +52,7 @@ class Zend_Measure_TemperatureTest extends \PHPUnit\Framework\TestCase
         setlocale(LC_ALL, 'de');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (is_string($this->_locale) && strpos($this->_locale, ';')) {
             $locales = array();

--- a/tests/Zend/Measure/VolumeTest.php
+++ b/tests/Zend/Measure/VolumeTest.php
@@ -37,11 +37,6 @@ require_once 'Zend/Measure/Volume.php';
 class Zend_Measure_VolumeTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function setUp()
-    {
-    }
-
-
     /**
      * test for Volume initialisation
      * expected instance

--- a/tests/Zend/RegistryTest.php
+++ b/tests/Zend/RegistryTest.php
@@ -35,12 +35,12 @@ require_once 'Zend/Registry.php';
  */
 class Zend_RegistryTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Registry::_unsetInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Registry::_unsetInstance();
     }
@@ -76,7 +76,7 @@ class Zend_RegistryTest extends \PHPUnit\Framework\TestCase
             Zend_Registry::get('foo');
             $this->fail('Expected exception when trying to fetch a non-existent key.');
         } catch (Zend_Exception $e) {
-            $this->assertContains('No entry is registered for key', $e->getMessage());
+            $this->assertStringContainsString('No entry is registered for key', $e->getMessage());
         }
         $registry = Zend_Registry::getInstance();
         $this->assertTrue($registry instanceof Zend_Registry);
@@ -142,7 +142,7 @@ class Zend_RegistryTest extends \PHPUnit\Framework\TestCase
             $registry = Zend_Registry::setClassName(new StdClass());
             $this->fail('Expected exception, because setClassName() wants a string');
         } catch (Zend_Exception $e) {
-            $this->assertContains('Argument is not a class name', $e->getMessage());
+            $this->assertStringContainsString('Argument is not a class name', $e->getMessage());
         }
     }
 
@@ -159,7 +159,7 @@ class Zend_RegistryTest extends \PHPUnit\Framework\TestCase
             $foo = Zend_Registry::get('foo');
             $this->fail('Expected exception when trying to fetch a non-existent key.');
         } catch (Zend_Exception $e) {
-            $this->assertContains('No entry is registered for key', $e->getMessage());
+            $this->assertStringContainsString('No entry is registered for key', $e->getMessage());
         }
     }
 
@@ -171,13 +171,13 @@ class Zend_RegistryTest extends \PHPUnit\Framework\TestCase
             Zend_Registry::setClassName('anyclass');
             $this->fail('Expected exception, because we cannot initialize the registry if it is already initialized.');
         } catch (Zend_Exception $e) {
-            $this->assertContains('Registry is already initialized', $e->getMessage());
+            $this->assertStringContainsString('Registry is already initialized', $e->getMessage());
         }
         try {
             Zend_Registry::setInstance(new Zend_Registry());
             $this->fail('Expected exception, because we cannot initialize the registry if it is already initialized.');
         } catch (Zend_Exception $e) {
-            $this->assertContains('Registry is already initialized', $e->getMessage());
+            $this->assertStringContainsString('Registry is already initialized', $e->getMessage());
         }
     }
 

--- a/tests/Zend/Rest/ControllerTest.php
+++ b/tests/Zend/Rest/ControllerTest.php
@@ -83,7 +83,7 @@ class Zend_Rest_ControllerTest extends \PHPUnit\Framework\TestCase
 {
     protected $_testController;
 
-    public function setUp()
+    public function setUp(): void
     {
         $request = new Zend_Controller_Request_HttpTestCase();
         $response = new Zend_Controller_Response_HttpTestCase();

--- a/tests/Zend/Rest/RouteTest.php
+++ b/tests/Zend/Rest/RouteTest.php
@@ -46,7 +46,7 @@ class Zend_Rest_RouteTest extends \PHPUnit\Framework\TestCase
     protected $_request;
     protected $_dispatcher;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_front = Zend_Controller_Front::getInstance();
         $this->_front->resetInstance();

--- a/tests/Zend/Test/DbAdapterTest.php
+++ b/tests/Zend/Test/DbAdapterTest.php
@@ -38,7 +38,7 @@ class Zend_Test_DbAdapterTest extends \PHPUnit\Framework\TestCase
      */
     private $_adapter = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_adapter = new Zend_Test_DbAdapter();
     }

--- a/tests/Zend/Test/PHPUnit/ControllerTestCaseTest.php
+++ b/tests/Zend/Test/PHPUnit/ControllerTestCaseTest.php
@@ -51,7 +51,7 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $_SESSION = array();
         $this->testCase = new Zend_Test_PHPUnit_ControllerTestCaseTest_Concrete();
@@ -65,7 +65,7 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $registry = Zend_Registry::getInstance();
         if (isset($registry['router'])) {
@@ -160,21 +160,21 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
             $this->testCase->request = new Zend_Controller_Request_Http();
             $this->fail('Setting request object as public property should raise exception');
         } catch (Exception $e) {
-            $this->assertContains('not allow', $e->getMessage());
+            $this->assertStringContainsString('not allow', $e->getMessage());
         }
 
         try {
             $this->testCase->response = new Zend_Controller_Response_Http();
             $this->fail('Setting response object as public property should raise exception');
         } catch (Exception $e) {
-            $this->assertContains('not allow', $e->getMessage());
+            $this->assertStringContainsString('not allow', $e->getMessage());
         }
 
         try {
             $this->testCase->frontController = Zend_Controller_Front::getInstance();
             $this->fail('Setting front controller as public property should raise exception');
         } catch (Exception $e) {
-            $this->assertContains('not allow', $e->getMessage());
+            $this->assertStringContainsString('not allow', $e->getMessage());
         }
     }
 
@@ -273,7 +273,7 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
         $content  = $response->getBody();
         $this->assertEquals('zend-test-php-unit-foo', $request->getControllerName(), $content);
         $this->assertEquals('bar', $request->getActionName());
-        $this->assertContains('FooController::barAction', $content, $content);
+        $this->assertStringContainsString('FooController::barAction', $content, $content);
     }
 
     public function testAssertQueryShouldDoNothingForValidResponseContent()
@@ -473,49 +473,49 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
             $this->testCase->assertResponseCode(500);
             $this->fail();
         } catch (Zend_Test_PHPUnit_Constraint_Exception $e) {
-            $this->assertContains('Failed', $e->getMessage());
+            $this->assertStringContainsString('Failed', $e->getMessage());
         }
         try {
             $this->testCase->assertNotResponseCode(200);
             $this->fail();
         } catch (Zend_Test_PHPUnit_Constraint_Exception $e) {
-            $this->assertContains('Failed', $e->getMessage());
+            $this->assertStringContainsString('Failed', $e->getMessage());
         }
         try {
             $this->testCase->assertNotHeader('Content-Type');
             $this->fail();
         } catch (Zend_Test_PHPUnit_Constraint_Exception $e) {
-            $this->assertContains('Failed', $e->getMessage());
+            $this->assertStringContainsString('Failed', $e->getMessage());
         }
         try {
             $this->testCase->assertHeader('X-Bogus');
             $this->fail();
         } catch (Zend_Test_PHPUnit_Constraint_Exception $e) {
-            $this->assertContains('Failed', $e->getMessage());
+            $this->assertStringContainsString('Failed', $e->getMessage());
         }
         try {
             $this->testCase->assertNotHeaderContains('Content-Type', 'my-foo');
             $this->fail();
         } catch (Zend_Test_PHPUnit_Constraint_Exception $e) {
-            $this->assertContains('Failed', $e->getMessage());
+            $this->assertStringContainsString('Failed', $e->getMessage());
         }
         try {
             $this->testCase->assertHeaderContains('Content-Type', 'my-bar');
             $this->fail();
         } catch (Zend_Test_PHPUnit_Constraint_Exception $e) {
-            $this->assertContains('Failed', $e->getMessage());
+            $this->assertStringContainsString('Failed', $e->getMessage());
         }
         try {
             $this->testCase->assertNotHeaderRegex('Content-Type', '#^[a-z-]+/[a-z-]+$#i');
             $this->fail();
         } catch (Zend_Test_PHPUnit_Constraint_Exception $e) {
-            $this->assertContains('Failed', $e->getMessage());
+            $this->assertStringContainsString('Failed', $e->getMessage());
         }
         try {
             $this->testCase->assertHeaderRegex('Content-Type', '#^\d+#i');
             $this->fail();
         } catch (Zend_Test_PHPUnit_Constraint_Exception $e) {
-            $this->assertContains('Failed', $e->getMessage());
+            $this->assertStringContainsString('Failed', $e->getMessage());
         }
     }
 
@@ -531,7 +531,7 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
     {
         $this->testCase->getFrontController()->setControllerDirectory(dirname(__FILE__) . '/_files/application/controllers');
         $this->testCase->dispatch('/zend-test-php-unit-foo/baz');
-        $this->expectException('\PHPUnit\Framework\AssertionFailedError');
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
         $this->testCase->assertModule('zend-test-php-unit-foo');
         $this->testCase->assertNotModule('default');
     }
@@ -548,7 +548,7 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
     {
         $this->testCase->getFrontController()->setControllerDirectory(dirname(__FILE__) . '/_files/application/controllers');
         $this->testCase->dispatch('/zend-test-php-unit-foo/baz');
-        $this->expectException('\PHPUnit\Framework\AssertionFailedError');
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
         $this->testCase->assertController('baz');
         $this->testCase->assertNotController('zend-test-php-unit-foo');
     }
@@ -565,7 +565,7 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
     {
         $this->testCase->getFrontController()->setControllerDirectory(dirname(__FILE__) . '/_files/application/controllers');
         $this->testCase->dispatch('/foo/baz');
-        $this->expectException('\PHPUnit\Framework\AssertionFailedError');
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
         $this->testCase->assertAction('foo');
         $this->testCase->assertNotAction('baz');
     }
@@ -582,7 +582,7 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
     {
         $this->testCase->getFrontController()->setControllerDirectory(dirname(__FILE__) . '/_files/application/controllers');
         $this->testCase->dispatch('/foo/baz');
-        $this->expectException('\PHPUnit\Framework\AssertionFailedError');
+        $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
         $this->testCase->assertRoute('foo');
         $this->testCase->assertNotRoute('default');
     }
@@ -641,7 +641,7 @@ class Zend_Test_PHPUnit_ControllerTestCaseTest extends \PHPUnit\Framework\TestCa
         $view = new Zend_View();
         $view->addHelperPath('Zend/Dojo/View/Helper', 'Zend_Dojo_View_Helper');
         $this->assertEquals(\Zend_View_Helper_Doctype::HTML4_LOOSE, $view->doctype()->getDoctype());
-        $this->assertNotContains('Foo', $view->headTitle()->__toString(), 'Head title persisted?');
+        $this->assertStringNotContainsString('Foo', $view->headTitle()->__toString(), 'Head title persisted?');
     }
 
     /**

--- a/tests/Zend/Test/PHPUnit/Db/ConnectionTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/ConnectionTest.php
@@ -35,7 +35,7 @@ class Zend_Test_PHPUnit_Db_ConnectionTest extends \PHPUnit\Framework\TestCase
 {
     protected $adapterMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->adapterMock = $this->createMock('Zend_Test_DbAdapter');
     }

--- a/tests/Zend/Test/PHPUnit/Db/DataSet/DataSetTestCase.php
+++ b/tests/Zend/Test/PHPUnit/Db/DataSet/DataSetTestCase.php
@@ -37,7 +37,7 @@ abstract class Zend_Test_PHPUnit_Db_DataSet_DataSetTestCase extends \PHPUnit\Fra
      */
     protected $connectionMock = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->connectionMock = $this->createMock('Zend_Test_PHPUnit_Db_Connection');
     }

--- a/tests/Zend/Test/PHPUnit/Db/DataSet/QueryDataSetTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/DataSet/QueryDataSetTest.php
@@ -47,7 +47,7 @@ class Zend_Test_PHPUnit_Db_DataSet_QueryDataSetTest extends Zend_Test_PHPUnit_Db
     public function testCreateQueryDataSetWithoutZendDbAdapterThrowsException()
     {
         $connectionMock = $this->createMock('\PHPUnit\DbUnit\Database\Connection');
-        $this->expectException('Zend_Test_PHPUnit_Db_Exception');
+        $this->expectException(Zend_Test_PHPUnit_Db_Exception::class);
         $queryDataSet = new Zend_Test_PHPUnit_Db_DataSet_QueryDataSet($connectionMock);
     }
 

--- a/tests/Zend/Test/PHPUnit/Db/Integration/MysqlIntegrationTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Integration/MysqlIntegrationTest.php
@@ -32,7 +32,7 @@ require_once "AbstractTestCase.php";
  */
 class Zend_Test_PHPUnit_Db_Integration_MysqlIntegrationTest extends Zend_Test_PHPUnit_Db_Integration_AbstractTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (!extension_loaded('pdo')) {
             $this->markTestSkipped('PDO is required for this test.');

--- a/tests/Zend/Test/PHPUnit/Db/Integration/SqLiteIntegrationTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Integration/SqLiteIntegrationTest.php
@@ -32,7 +32,7 @@ require_once "AbstractTestCase.php";
  */
 class Zend_Test_PHPUnit_Db_Integration_SqLiteIntegrationTest extends Zend_Test_PHPUnit_Db_Integration_AbstractTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->dbAdapter = Zend_Db::factory('pdo_sqlite', array('dbname' => ':memory:'));
         $this->dbAdapter->query(

--- a/tests/Zend/Test/PHPUnit/Db/Metadata/GenericTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Metadata/GenericTest.php
@@ -37,7 +37,7 @@ class Zend_Test_PHPUnit_Db_Metadata_GenericTest extends \PHPUnit\Framework\TestC
 
     private $metadata = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->adapterMock = $this->createMock('Zend_Test_DbAdapter');
         $this->metadata = new Zend_Test_PHPUnit_Db_Metadata_Generic($this->adapterMock, "schema");

--- a/tests/Zend/Test/PHPUnit/Db/Operation/DeleteAllTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Operation/DeleteAllTest.php
@@ -36,7 +36,7 @@ class Zend_Test_PHPUnit_Db_Operation_DeleteAllTest extends \PHPUnit\Framework\Te
 {
     private $operation = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->operation = new Zend_Test_PHPUnit_Db_Operation_DeleteAll();
     }
@@ -60,7 +60,7 @@ class Zend_Test_PHPUnit_Db_Operation_DeleteAllTest extends \PHPUnit\Framework\Te
 
     public function testDeleteQueryErrorTransformsException()
     {
-        $this->expectException('\PHPUnit\DbUnit\Operation\Exception');
+        $this->expectException(\PHPUnit\DbUnit\Operation\Exception::class);
 
         $dataSet = new \PHPUnit\DbUnit\DataSet\FlatXmlDataSet(dirname(__FILE__)."/_files/truncateFixture.xml");
 

--- a/tests/Zend/Test/PHPUnit/Db/Operation/InsertTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Operation/InsertTest.php
@@ -36,7 +36,7 @@ class Zend_Test_PHPUnit_Db_Operation_InsertTest extends \PHPUnit\Framework\TestC
 {
     private $operation = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->operation = new Zend_Test_PHPUnit_Db_Operation_Insert();
     }
@@ -63,7 +63,7 @@ class Zend_Test_PHPUnit_Db_Operation_InsertTest extends \PHPUnit\Framework\TestC
 
     public function testInsertExceptionIsTransformed()
     {
-        $this->expectException('\PHPUnit\DbUnit\Operation\Exception');
+        $this->expectException(\PHPUnit\DbUnit\Operation\Exception::class);
 
         $dataSet = new \PHPUnit\DbUnit\DataSet\FlatXmlDataSet(dirname(__FILE__)."/_files/insertFixture.xml");
 

--- a/tests/Zend/Test/PHPUnit/Db/Operation/TruncateTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/Operation/TruncateTest.php
@@ -36,7 +36,7 @@ class Zend_Test_PHPUnit_Db_Operation_TruncateTest extends \PHPUnit\Framework\Tes
 {
     private $operation = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->operation = new Zend_Test_PHPUnit_Db_Operation_Truncate();
     }
@@ -66,7 +66,7 @@ class Zend_Test_PHPUnit_Db_Operation_TruncateTest extends \PHPUnit\Framework\Tes
 
     public function testTruncateTableInvalidQueryTransformsException()
     {
-        $this->expectException('\PHPUnit\DbUnit\Operation\Exception');
+        $this->expectException(\PHPUnit\DbUnit\Operation\Exception::class);
 
         $dataSet = new \PHPUnit\DbUnit\DataSet\FlatXmlDataSet(dirname(__FILE__)."/_files/insertFixture.xml");
 
@@ -104,7 +104,7 @@ class Zend_Test_PHPUnit_Db_Operation_TruncateTest extends \PHPUnit\Framework\Tes
         $queries = $profiler->getQueryProfiles();
 
         $this->assertEquals(2, count($queries));
-        $this->assertContains('bar', $queries[0]->getQuery());
-        $this->assertContains('foo', $queries[1]->getQuery());
+        $this->assertStringContainsString('bar', $queries[0]->getQuery());
+        $this->assertStringContainsString('foo', $queries[1]->getQuery());
     }
 }

--- a/tests/Zend/Test/PHPUnit/Db/TestCaseTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/TestCaseTest.php
@@ -83,7 +83,7 @@ class Zend_Test_PHPUnit_Db_TestCaseTest extends Zend_Test_PHPUnit_DatabaseTestCa
     public function testCheckZendDbConnectionConvenienceMethodReturnType()
     {
         $mock = $this->getMockBuilder('Zend_Db_Adapter_Pdo_Sqlite')
-            ->setMethods(['delete'])
+            ->addMethods(['delete'])
             ->setMockClassName('Zend_Db_Adapter_Mock')
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Zend/Translate/Adapter/ArrayTest.php
+++ b/tests/Zend/Translate/Adapter/ArrayTest.php
@@ -42,7 +42,7 @@ class Zend_Translate_Adapter_ArrayTest extends \PHPUnit\Framework\TestCase
      */
     protected $_errorOccurred = false;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (Zend_Translate_Adapter_Array::hasCache()) {
             Zend_Translate_Adapter_Array::clearCache();
@@ -50,7 +50,7 @@ class Zend_Translate_Adapter_ArrayTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (Zend_Translate_Adapter_Array::hasCache()) {
             Zend_Translate_Adapter_Array::clearCache();
@@ -69,14 +69,14 @@ class Zend_Translate_Adapter_ArrayTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Array('hastofail', 'en');
             $this->fail('Exception expected');
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Error including array or file', $e->getMessage());
+            $this->assertStringContainsString('Error including array or file', $e->getMessage());
         }
 
         try {
             $adapter = new Zend_Translate_Adapter_Array(dirname(__FILE__) . '/_files/failed.php', 'en');
             $this->fail('Exception expected');
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Error including array or file', $e->getMessage());
+            $this->assertStringContainsString('Error including array or file', $e->getMessage());
         }
     }
 
@@ -123,7 +123,7 @@ class Zend_Translate_Adapter_ArrayTest extends \PHPUnit\Framework\TestCase
             $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en.php', 'xx');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.php', 'de', array('clear' => true));
@@ -182,7 +182,7 @@ class Zend_Translate_Adapter_ArrayTest extends \PHPUnit\Framework\TestCase
             $adapter->setLocale('nolocale');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));

--- a/tests/Zend/Translate/Adapter/CsvTest.php
+++ b/tests/Zend/Translate/Adapter/CsvTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Translate/Adapter/Csv.php';
  */
 class Zend_Translate_Adapter_CsvTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (Zend_Translate_Adapter_Csv::hasCache()) {
             Zend_Translate_Adapter_Csv::removeCache();
@@ -51,7 +51,7 @@ class Zend_Translate_Adapter_CsvTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Csv(dirname(__FILE__) . '/_files/nofile.csv', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Error opening translation file', $e->getMessage());
+            $this->assertStringContainsString('Error opening translation file', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));
@@ -98,7 +98,7 @@ class Zend_Translate_Adapter_CsvTest extends \PHPUnit\Framework\TestCase
             $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en.csv', 'xx');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.csv', 'de', array('clear' => true));
@@ -159,7 +159,7 @@ class Zend_Translate_Adapter_CsvTest extends \PHPUnit\Framework\TestCase
             $adapter->setLocale('nolocale');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));

--- a/tests/Zend/Translate/Adapter/GettextTest.php
+++ b/tests/Zend/Translate/Adapter/GettextTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Translate/Adapter/Gettext.php';
  */
 class Zend_Translate_Adapter_GettextTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (Zend_Translate_Adapter_Gettext::hasCache()) {
             Zend_Translate_Adapter_Gettext::removeCache();
@@ -51,14 +51,14 @@ class Zend_Translate_Adapter_GettextTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Gettext(dirname(__FILE__) . '/_files/nofile.mo', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Error opening translation file', $e->getMessage());
+            $this->assertStringContainsString('Error opening translation file', $e->getMessage());
         }
 
         try {
             $adapter = new Zend_Translate_Adapter_Gettext(dirname(__FILE__) . '/_files/failed.mo', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('is not a gettext file', $e->getMessage());
+            $this->assertStringContainsString('is not a gettext file', $e->getMessage());
         }
     }
 
@@ -101,7 +101,7 @@ class Zend_Translate_Adapter_GettextTest extends \PHPUnit\Framework\TestCase
             $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.mo', 'xx');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.mo', 'de', array('clear' => true));
@@ -159,7 +159,7 @@ class Zend_Translate_Adapter_GettextTest extends \PHPUnit\Framework\TestCase
             $adapter->setLocale('nolocale');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));
@@ -207,7 +207,7 @@ class Zend_Translate_Adapter_GettextTest extends \PHPUnit\Framework\TestCase
         $adapter = new Zend_Translate_Adapter_Gettext(dirname(__FILE__) . '/_files/translation_en.mo');
         $this->assertEquals('', $adapter->translate(''));
         $info = $adapter->getAdapterInfo();
-        $this->assertContains('Last-Translator: Thomas Weidner <thomas.weidner@voxtronic.com>', $info[dirname(__FILE__) . '/_files/translation_en.mo']);
+        $this->assertStringContainsString('Last-Translator: Thomas Weidner <thomas.weidner@voxtronic.com>', $info[dirname(__FILE__) . '/_files/translation_en.mo']);
     }
 
     public function testOtherEncoding()
@@ -232,14 +232,14 @@ class Zend_Translate_Adapter_GettextTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Gettext(dirname(__FILE__) . '/_files/failed2.mo', 'en');
             $this->fail('Exception expected');
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('is not a gettext file', $e->getMessage());
+            $this->assertStringContainsString('is not a gettext file', $e->getMessage());
         }
     }
 
     public function testMissingAdapterInfo()
     {
         $adapter = new Zend_Translate_Adapter_Gettext(dirname(__FILE__) . '/_files/failed3.mo', 'en');
-        $this->assertContains('No adapter information available', current($adapter->getAdapterInfo()));
+        $this->assertStringContainsString('No adapter information available', current($adapter->getAdapterInfo()));
     }
 
     /**

--- a/tests/Zend/Translate/Adapter/IniTest.php
+++ b/tests/Zend/Translate/Adapter/IniTest.php
@@ -44,7 +44,7 @@ class Zend_Translate_Adapter_IniTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Ini(dirname(__FILE__) . '/_files/nofile.ini', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));
@@ -91,7 +91,7 @@ class Zend_Translate_Adapter_IniTest extends \PHPUnit\Framework\TestCase
             $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en.ini', 'xx');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('The given Language', $e->getMessage());
+            $this->assertStringContainsString('The given Language', $e->getMessage());
         }
 
         $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.ini', 'de', array('clear' => true));
@@ -149,7 +149,7 @@ class Zend_Translate_Adapter_IniTest extends \PHPUnit\Framework\TestCase
             $adapter->setLocale('nolocale');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('The given Language', $e->getMessage());
+            $this->assertStringContainsString('The given Language', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));

--- a/tests/Zend/Translate/Adapter/QtTest.php
+++ b/tests/Zend/Translate/Adapter/QtTest.php
@@ -44,14 +44,14 @@ class Zend_Translate_Adapter_QtTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Qt(dirname(__FILE__) . '/_files/nofile.ts', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('is not readable', $e->getMessage());
+            $this->assertStringContainsString('is not readable', $e->getMessage());
         }
 
         try {
             $adapter = new Zend_Translate_Adapter_Qt(dirname(__FILE__) . '/_files/failed.ts', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Mismatched tag at line', $e->getMessage());
+            $this->assertStringContainsString('Mismatched tag at line', $e->getMessage());
         }
     }
 
@@ -64,7 +64,7 @@ class Zend_Translate_Adapter_QtTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Qt(dirname(__FILE__) . '/_files/nofile.ts', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('nofile.ts', $e->getMessage());
+            $this->assertStringContainsString('nofile.ts', $e->getMessage());
         }
     }
 
@@ -107,7 +107,7 @@ class Zend_Translate_Adapter_QtTest extends \PHPUnit\Framework\TestCase
             $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en.ts', 'xx');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.ts', 'de', array('clear' => true));
@@ -165,7 +165,7 @@ class Zend_Translate_Adapter_QtTest extends \PHPUnit\Framework\TestCase
             $adapter->setLocale('nolocale');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));

--- a/tests/Zend/Translate/Adapter/TbxTest.php
+++ b/tests/Zend/Translate/Adapter/TbxTest.php
@@ -44,14 +44,14 @@ class Zend_Translate_Adapter_TbxTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Tbx(dirname(__FILE__) . '/_files/nofile.tbx', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('is not readable', $e->getMessage());
+            $this->assertStringContainsString('is not readable', $e->getMessage());
         }
 
         try {
             $adapter = new Zend_Translate_Adapter_Tbx(dirname(__FILE__) . '/_files/failed.tbx', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Mismatched tag at line', $e->getMessage());
+            $this->assertStringContainsString('Mismatched tag at line', $e->getMessage());
         }
     }
 
@@ -64,7 +64,7 @@ class Zend_Translate_Adapter_TbxTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Tbx(dirname(__FILE__) . '/_files/nofile.tbx', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('nofile.tbx', $e->getMessage());
+            $this->assertStringContainsString('nofile.tbx', $e->getMessage());
         }
     }
 
@@ -106,7 +106,7 @@ class Zend_Translate_Adapter_TbxTest extends \PHPUnit\Framework\TestCase
             $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en.tbx', 'xx');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.tbx', 'de', array('clear' => true));
@@ -164,7 +164,7 @@ class Zend_Translate_Adapter_TbxTest extends \PHPUnit\Framework\TestCase
             $adapter->setLocale('nolocale');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));

--- a/tests/Zend/Translate/Adapter/TmxTest.php
+++ b/tests/Zend/Translate/Adapter/TmxTest.php
@@ -44,14 +44,14 @@ class Zend_Translate_Adapter_TmxTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Tmx(dirname(__FILE__) . '/_files/nofile.tmx', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('is not readable', $e->getMessage());
+            $this->assertStringContainsString('is not readable', $e->getMessage());
         }
 
         try {
             $adapter = new Zend_Translate_Adapter_Tmx(dirname(__FILE__) . '/_files/failed.tmx', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Mismatched tag at line', $e->getMessage());
+            $this->assertStringContainsString('Mismatched tag at line', $e->getMessage());
         }
     }
 
@@ -64,7 +64,7 @@ class Zend_Translate_Adapter_TmxTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Tmx(dirname(__FILE__) . '/_files/nofile.tmx', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('nofile.tmx', $e->getMessage());
+            $this->assertStringContainsString('nofile.tmx', $e->getMessage());
         }
     }
 
@@ -107,7 +107,7 @@ class Zend_Translate_Adapter_TmxTest extends \PHPUnit\Framework\TestCase
             $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en.tmx', 'xx');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.tmx', 'de', array('clear' => true));
@@ -165,7 +165,7 @@ class Zend_Translate_Adapter_TmxTest extends \PHPUnit\Framework\TestCase
             $adapter->setLocale('nolocale');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));

--- a/tests/Zend/Translate/Adapter/XliffTest.php
+++ b/tests/Zend/Translate/Adapter/XliffTest.php
@@ -44,14 +44,14 @@ class Zend_Translate_Adapter_XliffTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Xliff(dirname(__FILE__) . '/_files/nofile.xliff', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('is not readable', $e->getMessage());
+            $this->assertStringContainsString('is not readable', $e->getMessage());
         }
 
         try {
             $adapter = new Zend_Translate_Adapter_Xliff(dirname(__FILE__) . '/_files/failed.xliff', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Mismatched tag at line', $e->getMessage());
+            $this->assertStringContainsString('Mismatched tag at line', $e->getMessage());
         }
     }
 
@@ -64,7 +64,7 @@ class Zend_Translate_Adapter_XliffTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_Xliff(dirname(__FILE__) . '/_files/nofile.xliff', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('nofile.xliff', $e->getMessage());
+            $this->assertStringContainsString('nofile.xliff', $e->getMessage());
         }
     }
 
@@ -107,7 +107,7 @@ class Zend_Translate_Adapter_XliffTest extends \PHPUnit\Framework\TestCase
             $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en.xliff', 'xx');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.xliff', 'de', array('clear' => true));
@@ -165,7 +165,7 @@ class Zend_Translate_Adapter_XliffTest extends \PHPUnit\Framework\TestCase
             $adapter->setLocale('nolocale');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));

--- a/tests/Zend/Translate/Adapter/XmlTmTest.php
+++ b/tests/Zend/Translate/Adapter/XmlTmTest.php
@@ -44,14 +44,14 @@ class Zend_Translate_Adapter_XmlTmTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_XmlTm(dirname(__FILE__) . '/_files/nofile.xmltm', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('is not readable', $e->getMessage());
+            $this->assertStringContainsString('is not readable', $e->getMessage());
         }
 
         try {
             $adapter = new Zend_Translate_Adapter_XmlTm(dirname(__FILE__) . '/_files/failed.xmltm', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Mismatched tag at line', $e->getMessage());
+            $this->assertStringContainsString('Mismatched tag at line', $e->getMessage());
         }
     }
 
@@ -64,7 +64,7 @@ class Zend_Translate_Adapter_XmlTmTest extends \PHPUnit\Framework\TestCase
             $adapter = new Zend_Translate_Adapter_XmlTm(dirname(__FILE__) . '/_files/nofile.xmltm', 'en');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('nofile.xmltm', $e->getMessage());
+            $this->assertStringContainsString('nofile.xmltm', $e->getMessage());
         }
     }
 
@@ -107,7 +107,7 @@ class Zend_Translate_Adapter_XmlTmTest extends \PHPUnit\Framework\TestCase
             $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en.xmltm', 'xx');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         $adapter->addTranslation(dirname(__FILE__) . '/_files/translation_en2.xmltm', 'de', array('clear' => true));
@@ -165,7 +165,7 @@ class Zend_Translate_Adapter_XmlTmTest extends \PHPUnit\Framework\TestCase
             $adapter->setLocale('nolocale');
             $this->fail("exception expected");
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not exist', $e->getMessage());
+            $this->assertStringContainsString('does not exist', $e->getMessage());
         }
 
         set_error_handler(array($this, 'errorHandlerIgnore'));

--- a/tests/Zend/TranslateTest.php
+++ b/tests/Zend/TranslateTest.php
@@ -41,7 +41,7 @@ require_once 'Zend/Translate/Plural.php';
 class Zend_TranslateTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         if (Zend_Translate::hasCache()) {
             Zend_Translate::removeCache();
@@ -254,7 +254,7 @@ class Zend_TranslateTest extends \PHPUnit\Framework\TestCase
             $lang = new Zend_Translate('Zend_Locale', dirname(__FILE__) . '/Translate/_files/test2', null, array('scan' => Zend_Translate::LOCALE_FILENAME));
             $this->fail('Exception due to false adapter class expected');
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('does not extend Zend_Translate_Adapter', $e->getMessage());
+            $this->assertStringContainsString('does not extend Zend_Translate_Adapter', $e->getMessage());
         }
     }
 
@@ -317,7 +317,7 @@ class Zend_TranslateTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('ignored', $lang->translate('ignored'));
 
         rewind($stream);
-        $this->assertContains('ignored', stream_get_contents($stream));
+        $this->assertStringContainsString('ignored', stream_get_contents($stream));
     }
 
     public function testSettingUnknownLocaleWithTriggeredError()
@@ -345,7 +345,7 @@ class Zend_TranslateTest extends \PHPUnit\Framework\TestCase
         $lang->setLocale('ru');
 
         rewind($stream);
-        $this->assertContains('has to be added', stream_get_contents($stream));
+        $this->assertStringContainsString('has to be added', stream_get_contents($stream));
     }
 
     public function testSettingNoLogAsLog()
@@ -356,7 +356,7 @@ class Zend_TranslateTest extends \PHPUnit\Framework\TestCase
             $lang->setOptions(array('log' => 'nolog'));
             $this->fail();
         } catch (Zend_Translate_Exception $e) {
-            $this->assertContains('Instance of Zend_Log expected', $e->getMessage());
+            $this->assertStringContainsString('Instance of Zend_Log expected', $e->getMessage());
         }
     }
 
@@ -375,7 +375,7 @@ class Zend_TranslateTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('ignored', $lang->translate('ignored'));
 
         rewind($stream);
-        $this->assertContains('Self defined log message', stream_get_contents($stream));
+        $this->assertStringContainsString('Self defined log message', stream_get_contents($stream));
     }
 
     /**
@@ -597,7 +597,7 @@ class Zend_TranslateTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($lang->isTranslated('ignored'));
 
         rewind($stream);
-        $this->assertNotContains('ignored', stream_get_contents($stream));
+        $this->assertStringNotContainsString('ignored', stream_get_contents($stream));
     }
 
     /**
@@ -876,13 +876,13 @@ class Zend_TranslateTest extends \PHPUnit\Framework\TestCase
         $lang->setLocale('ru');
 
         rewind($stream);
-        $this->assertContains('ERR (3)', stream_get_contents($stream));
+        $this->assertStringContainsString('ERR (3)', stream_get_contents($stream));
 
         $lang->setOptions(array('logPriority' => 1));
         $lang->setLocale('sv');
 
         rewind($stream);
-        $this->assertContains('ALERT (1)', stream_get_contents($stream));
+        $this->assertStringContainsString('ALERT (1)', stream_get_contents($stream));
     }
 
     /**

--- a/tests/Zend/Uri/HttpTest.php
+++ b/tests/Zend/Uri/HttpTest.php
@@ -42,7 +42,7 @@ require_once 'Zend/Uri/Http.php';
 class Zend_Uri_HttpTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function setup()
+    public function setup(): void
     {
         Zend_Uri::setConfig(array('allow_unwise' => false));
     }

--- a/tests/Zend/UriTest.php
+++ b/tests/Zend/UriTest.php
@@ -41,14 +41,14 @@ require_once 'Zend/Config.php';
 class Zend_UriTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->notices = array();
         $this->errorReporting = error_reporting();
         $this->displayErrors  = ini_get('display_errors');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         error_reporting($this->errorReporting);
         ini_set('display_errors', $this->displayErrors);
@@ -132,7 +132,7 @@ class Zend_UriTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue(empty($text));
         $this->assertTrue(isset($this->error));
-        $this->assertContains('Exception in getUri()', $this->error);
+        $this->assertStringContainsString('Exception in getUri()', $this->error);
 
     }
 

--- a/tests/Zend/Validate/AbstractTest.php
+++ b/tests/Zend/Validate/AbstractTest.php
@@ -52,14 +52,14 @@ class Zend_Validate_AbstractTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->clearRegistry();
         Zend_Validate_Abstract::setDefaultTranslator(null);
         $this->validator = new Zend_Validate_AbstractTest_Concrete();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->clearRegistry();
         Zend_Validate_Abstract::setDefaultTranslator(null);
@@ -141,8 +141,8 @@ class Zend_Validate_AbstractTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->validator->isValid('bar'));
         $messages = $this->validator->getMessages();
         $this->assertTrue(array_key_exists('fooMessage', $messages));
-        $this->assertContains('bar', $messages['fooMessage']);
-        $this->assertContains('This is the translated message for ', $messages['fooMessage']);
+        $this->assertStringContainsString('bar', $messages['fooMessage']);
+        $this->assertStringContainsString('This is the translated message for ', $messages['fooMessage']);
     }
 
     public function testCanTranslateMessagesInsteadOfKeys()
@@ -156,8 +156,8 @@ class Zend_Validate_AbstractTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->validator->isValid('bar'));
         $messages = $this->validator->getMessages();
         $this->assertTrue(array_key_exists('fooMessage', $messages));
-        $this->assertContains('bar', $messages['fooMessage']);
-        $this->assertContains('This is the translated message for ', $messages['fooMessage']);
+        $this->assertStringContainsString('bar', $messages['fooMessage']);
+        $this->assertStringContainsString('This is the translated message for ', $messages['fooMessage']);
     }
 
     public function testObscureValueFlagFalseByDefault()
@@ -181,8 +181,8 @@ class Zend_Validate_AbstractTest extends \PHPUnit\Framework\TestCase
         $messages = $this->validator->getMessages();
         $this->assertTrue(isset($messages['fooMessage']));
         $message = $messages['fooMessage'];
-        $this->assertNotContains('foobar', $message);
-        $this->assertContains('******', $message);
+        $this->assertStringNotContainsString('foobar', $message);
+        $this->assertStringContainsString('******', $message);
     }
 
     /**
@@ -218,8 +218,8 @@ class Zend_Validate_AbstractTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->validator->isValid('bar'));
         $messages = $this->validator->getMessages();
         $this->assertTrue(array_key_exists('fooMessage', $messages));
-        $this->assertContains('bar', $messages['fooMessage']);
-        $this->assertContains('This is the translated message for ', $messages['fooMessage']);
+        $this->assertStringContainsString('bar', $messages['fooMessage']);
+        $this->assertStringContainsString('This is the translated message for ', $messages['fooMessage']);
 
         $this->validator->setDisableTranslator(true);
         $this->assertTrue($this->validator->translatorIsDisabled());
@@ -227,8 +227,8 @@ class Zend_Validate_AbstractTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->validator->isValid('bar'));
         $messages = $this->validator->getMessages();
         $this->assertTrue(array_key_exists('fooMessage', $messages));
-        $this->assertContains('bar', $messages['fooMessage']);
-        $this->assertContains('bar was passed', $messages['fooMessage']);
+        $this->assertStringContainsString('bar', $messages['fooMessage']);
+        $this->assertStringContainsString('bar was passed', $messages['fooMessage']);
     }
 
     public function testGetMessageTemplates()

--- a/tests/Zend/Validate/AlnumTest.php
+++ b/tests/Zend/Validate/AlnumTest.php
@@ -48,7 +48,7 @@ class Zend_Validate_AlnumTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_Alnum();
     }

--- a/tests/Zend/Validate/AlphaTest.php
+++ b/tests/Zend/Validate/AlphaTest.php
@@ -48,7 +48,7 @@ class Zend_Validate_AlphaTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_Alpha();
     }

--- a/tests/Zend/Validate/BarcodeTest.php
+++ b/tests/Zend/Validate/BarcodeTest.php
@@ -148,7 +148,7 @@ class Zend_Validate_BarcodeTest extends \PHPUnit\Framework\TestCase
             $barcode->setAdapter('MyBarcode5');
             $this->fails('Exception expected');
         } catch (Exception $e) {
-            $this->assertContains('does not implement', $e->getMessage());
+            $this->assertStringContainsString('does not implement', $e->getMessage());
         }
     }
 
@@ -165,7 +165,7 @@ class Zend_Validate_BarcodeTest extends \PHPUnit\Framework\TestCase
             $barcode = new Zend_Validate_Barcode(array('options' => 'unknown', 'checksum' => false));
             $this->fails('Exception expected');
         } catch (Exception $e) {
-            $this->assertContains('Missing option', $e->getMessage());
+            $this->assertStringContainsString('Missing option', $e->getMessage());
         }
     }
 
@@ -437,6 +437,6 @@ class Zend_Validate_BarcodeTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($barcode->isValid('123'));
         $message = $barcode->getMessages();
         $this->assertTrue(array_key_exists('barcodeInvalidLength', $message));
-        $this->assertContains("length of 7/8 characters", $message['barcodeInvalidLength']);
+        $this->assertStringContainsString("length of 7/8 characters", $message['barcodeInvalidLength']);
     }
 }

--- a/tests/Zend/Validate/CallbackTest.php
+++ b/tests/Zend/Validate/CallbackTest.php
@@ -82,7 +82,7 @@ class Zend_Validate_CallbackTest extends \PHPUnit\Framework\TestCase
             $valid->setCallback('invalidcallback');
             $this->fail('Exception expected');
         } catch (Zend_Exception $e) {
-            $this->assertContains('Invalid callback given', $e->getMessage());
+            $this->assertStringContainsString('Invalid callback given', $e->getMessage());
         }
     }
 

--- a/tests/Zend/Validate/CcnumTest.php
+++ b/tests/Zend/Validate/CcnumTest.php
@@ -48,7 +48,7 @@ class Zend_Validate_CcnumTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         set_error_handler(array($this, 'errorHandlerIgnore'));
         $this->_validator = new Zend_Validate_Ccnum();

--- a/tests/Zend/Validate/CreditCardTest.php
+++ b/tests/Zend/Validate/CreditCardTest.php
@@ -202,7 +202,7 @@ class Zend_Validate_CreditCardTest extends \PHPUnit\Framework\TestCase
             $validator->setService(array('Zend_Validate_CreditCardTest', 'nocallback'));
             $this->fail('Exception expected');
         } catch(Zend_Exception $e) {
-            $this->assertContains('Invalid callback given', $e->getMessage());
+            $this->assertStringContainsString('Invalid callback given', $e->getMessage());
         }
     }
 
@@ -255,7 +255,7 @@ class Zend_Validate_CreditCardTest extends \PHPUnit\Framework\TestCase
         $validator      = new Zend_Validate_CreditCard(array('type' => Zend_Validate_CreditCard::MASTERCARD));
         $this->assertFalse($validator->isValid('4111111111111111'));
         $message = $validator->getMessages();
-        $this->assertContains('not from an allowed institute', current($message));
+        $this->assertStringContainsString('not from an allowed institute', current($message));
     }
 
     public static function staticCallback($value)

--- a/tests/Zend/Validate/DateTest.php
+++ b/tests/Zend/Validate/DateTest.php
@@ -54,7 +54,7 @@ class Zend_Validate_DateTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_Date();
     }

--- a/tests/Zend/Validate/Db/NoRecordExistsTest.php
+++ b/tests/Zend/Validate/Db/NoRecordExistsTest.php
@@ -83,7 +83,7 @@ class Zend_Validate_Db_NoRecordExistsTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_adapterHasResult = new Db_MockHasResult();
         $this->_adapterNoResult = new Db_MockNoResult();

--- a/tests/Zend/Validate/Db/RecordExistsTest.php
+++ b/tests/Zend/Validate/Db/RecordExistsTest.php
@@ -82,7 +82,7 @@ class Zend_Validate_Db_RecordExistsTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_adapterHasResult = new Db_MockHasResult();
         $this->_adapterNoResult = new Db_MockNoResult();

--- a/tests/Zend/Validate/DigitsTest.php
+++ b/tests/Zend/Validate/DigitsTest.php
@@ -48,7 +48,7 @@ class Zend_Validate_DigitsTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_Digits();
     }

--- a/tests/Zend/Validate/EmailAddressTest.php
+++ b/tests/Zend/Validate/EmailAddressTest.php
@@ -47,7 +47,7 @@ class Zend_Validate_EmailAddressTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_EmailAddress();
     }
@@ -113,7 +113,7 @@ class Zend_Validate_EmailAddressTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->_validator->isValid('@example.com'));
         $messages = $this->_validator->getMessages();
         $this->assertEquals(1, count($messages));
-        $this->assertContains('local-part@hostname', current($messages));
+        $this->assertStringContainsString('local-part@hostname', current($messages));
     }
 
     /**
@@ -129,14 +129,14 @@ class Zend_Validate_EmailAddressTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(3, count($messages));
 
-        $this->assertContains('Some User', current($messages));
-        $this->assertContains('dot-atom', current($messages));
+        $this->assertStringContainsString('Some User', current($messages));
+        $this->assertStringContainsString('dot-atom', current($messages));
 
-        $this->assertContains('Some User', next($messages));
-        $this->assertContains('quoted-string', current($messages));
+        $this->assertStringContainsString('Some User', next($messages));
+        $this->assertStringContainsString('quoted-string', current($messages));
 
-        $this->assertContains('Some User', next($messages));
-        $this->assertContains('not a valid local part', current($messages));
+        $this->assertStringContainsString('Some User', next($messages));
+        $this->assertStringContainsString('not a valid local part', current($messages));
     }
 
     /**
@@ -164,7 +164,7 @@ class Zend_Validate_EmailAddressTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->_validator->isValid('username@ example . com'));
         $messages = $this->_validator->getMessages();
         $this->assertThat(count($messages), $this->greaterThanOrEqual(1));
-        $this->assertContains('not a valid hostname', current($messages));
+        $this->assertStringContainsString('not a valid hostname', current($messages));
     }
 
     /**
@@ -235,9 +235,9 @@ class Zend_Validate_EmailAddressTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->_validator->isValid('User Name <username@example.com>'));
         $messages = $this->_validator->getMessages();
         $this->assertThat(count($messages), $this->greaterThanOrEqual(3));
-        $this->assertContains('not a valid hostname', current($messages));
-        $this->assertContains('cannot match TLD', next($messages));
-        $this->assertContains('does not appear to be a valid local network name', next($messages));
+        $this->assertStringContainsString('not a valid hostname', current($messages));
+        $this->assertStringContainsString('cannot match TLD', next($messages));
+        $this->assertStringContainsString('does not appear to be a valid local network name', next($messages));
     }
 
     /**

--- a/tests/Zend/Validate/File/CountTest.php
+++ b/tests/Zend/Validate/File/CountTest.php
@@ -89,7 +89,7 @@ class Zend_Validate_File_CountTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_Count(array('min' => 5, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
 
         $validator = new Zend_Validate_File_Count(array('min' => 1, 'max' => 5));
@@ -99,7 +99,7 @@ class Zend_Validate_File_CountTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_Count(array('min' => 5, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
     }
 
@@ -118,7 +118,7 @@ class Zend_Validate_File_CountTest extends \PHPUnit\Framework\TestCase
             $validator->setMin(20000);
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("less than or equal", $e->getMessage());
+            $this->assertStringContainsString("less than or equal", $e->getMessage());
         }
     }
 
@@ -136,7 +136,7 @@ class Zend_Validate_File_CountTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_Count(array('min' => 5, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
     }
 

--- a/tests/Zend/Validate/File/FilesSizeTest.php
+++ b/tests/Zend/Validate/File/FilesSizeTest.php
@@ -35,7 +35,7 @@ require_once 'Zend/Validate/File/FilesSize.php';
  */
 class Zend_Validate_File_FilesSizeTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->multipleOptionsDetected = false;
     }
@@ -102,7 +102,7 @@ class Zend_Validate_File_FilesSizeTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_FilesSize(array('min' => 100, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
 
         $validator = new Zend_Validate_File_FilesSize(array('min' => 1, 'max' => 100));
@@ -124,7 +124,7 @@ class Zend_Validate_File_FilesSizeTest extends \PHPUnit\Framework\TestCase
             $validator->setMin(20000);
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("less than or equal", $e->getMessage());
+            $this->assertStringContainsString("less than or equal", $e->getMessage());
         }
     }
 
@@ -142,7 +142,7 @@ class Zend_Validate_File_FilesSizeTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_FilesSize(array('min' => 100, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
 
         $validator = new Zend_Validate_File_FilesSize(array('min' => 1, 'max' => 100000));
@@ -188,16 +188,16 @@ class Zend_Validate_File_FilesSizeTest extends \PHPUnit\Framework\TestCase
             dirname(__FILE__) . '/_files/testsize.mo',
             dirname(__FILE__) . '/_files/testsize.mo',
             dirname(__FILE__) . '/_files/testsize2.mo')));
-        $this->assertContains('9.76kB', current($validator->getMessages()));
-        $this->assertContains('1.55kB', current($validator->getMessages()));
+        $this->assertStringContainsString('9.76kB', current($validator->getMessages()));
+        $this->assertStringContainsString('1.55kB', current($validator->getMessages()));
 
         $validator = new Zend_Validate_File_FilesSize(array('min' => 9999, 'max' => 10000, 'bytestring' => false));
         $this->assertFalse($validator->isValid(array(
             dirname(__FILE__) . '/_files/testsize.mo',
             dirname(__FILE__) . '/_files/testsize.mo',
             dirname(__FILE__) . '/_files/testsize2.mo')));
-        $this->assertContains('9999', current($validator->getMessages()));
-        $this->assertContains('1588', current($validator->getMessages()));
+        $this->assertStringContainsString('9999', current($validator->getMessages()));
+        $this->assertStringContainsString('1588', current($validator->getMessages()));
     }
 
     public function errorHandler($errno, $errstr)

--- a/tests/Zend/Validate/File/ImageSizeTest.php
+++ b/tests/Zend/Validate/File/ImageSizeTest.php
@@ -65,18 +65,18 @@ class Zend_Validate_File_ImageSizeTest extends \PHPUnit\Framework\TestCase
         $validator = new Zend_Validate_File_ImageSize(array('minwidth' => 0, 'minheight' => 10, 'maxwidth' => 1000, 'maxheight' => 2000));
         $this->assertEquals(false, $validator->isValid(dirname(__FILE__) . '/_files/nofile.jpg'));
         $failures = $validator->getMessages();
-        $this->assertContains('is not readable', $failures['fileImageSizeNotReadable']);
+        $this->assertStringContainsString('is not readable', $failures['fileImageSizeNotReadable']);
 
         $file['name'] = 'TestName';
         $validator = new Zend_Validate_File_ImageSize(array('minwidth' => 0, 'minheight' => 10, 'maxwidth' => 1000, 'maxheight' => 2000));
         $this->assertEquals(false, $validator->isValid(dirname(__FILE__) . '/_files/nofile.jpg', $file));
         $failures = $validator->getMessages();
-        $this->assertContains('TestName', $failures['fileImageSizeNotReadable']);
+        $this->assertStringContainsString('TestName', $failures['fileImageSizeNotReadable']);
 
         $validator = new Zend_Validate_File_ImageSize(array('minwidth' => 0, 'minheight' => 10, 'maxwidth' => 1000, 'maxheight' => 2000));
         $this->assertEquals(false, $validator->isValid(dirname(__FILE__) . '/_files/badpicture.jpg'));
         $failures = $validator->getMessages();
-        $this->assertContains('could not be detected', $failures['fileImageSizeNotDetected']);
+        $this->assertStringContainsString('could not be detected', $failures['fileImageSizeNotDetected']);
     }
 
     /**
@@ -93,7 +93,7 @@ class Zend_Validate_File_ImageSizeTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_ImageSize(array('minwidth' => 1000, 'minheight' => 100, 'maxwidth' => 10, 'maxheight' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
     }
 
@@ -115,7 +115,7 @@ class Zend_Validate_File_ImageSizeTest extends \PHPUnit\Framework\TestCase
             $validator->setImageMin(array('minwidth' => 20000, 'minheight' => 20000));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("less than or equal", $e->getMessage());
+            $this->assertStringContainsString("less than or equal", $e->getMessage());
         }
     }
 
@@ -133,7 +133,7 @@ class Zend_Validate_File_ImageSizeTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_ImageSize(array('minwidth' => 10000, 'minheight' => 1000, 'maxwidth' => 100, 'maxheight' => 10));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
     }
 
@@ -161,7 +161,7 @@ class Zend_Validate_File_ImageSizeTest extends \PHPUnit\Framework\TestCase
             $validator->setImageMax(array('maxwidth' => 10000, 'maxheight' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
     }
 
@@ -191,7 +191,7 @@ class Zend_Validate_File_ImageSizeTest extends \PHPUnit\Framework\TestCase
             $validator->setImageWidth(array('minwidth' => 20000, 'maxwidth' => 200));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("less than or equal", $e->getMessage());
+            $this->assertStringContainsString("less than or equal", $e->getMessage());
         }
     }
 
@@ -221,7 +221,7 @@ class Zend_Validate_File_ImageSizeTest extends \PHPUnit\Framework\TestCase
             $validator->setImageHeight(array('minheight' => 20000, 'maxheight' => 200));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("less than or equal", $e->getMessage());
+            $this->assertStringContainsString("less than or equal", $e->getMessage());
         }
     }
 }

--- a/tests/Zend/Validate/File/MimeTypeTest.php
+++ b/tests/Zend/Validate/File/MimeTypeTest.php
@@ -154,7 +154,7 @@ class Zend_Validate_File_MimeTypeTest extends \PHPUnit\Framework\TestCase
         try {
             $validator->setMagicFile('/unknown/magic/file');
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains('can not be', $e->getMessage());
+            $this->assertStringContainsString('can not be', $e->getMessage());
         }
     }
 

--- a/tests/Zend/Validate/File/SizeTest.php
+++ b/tests/Zend/Validate/File/SizeTest.php
@@ -80,7 +80,7 @@ class Zend_Validate_File_SizeTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_Size(array('min' => 100, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
 
         $validator = new Zend_Validate_File_Size(array('min' => 1, 'max' => 100, 'bytestring' => false));
@@ -102,7 +102,7 @@ class Zend_Validate_File_SizeTest extends \PHPUnit\Framework\TestCase
             $validator->setMin(20000);
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("less than or equal", $e->getMessage());
+            $this->assertStringContainsString("less than or equal", $e->getMessage());
         }
 
         $validator = new Zend_Validate_File_Size(array('min' => 1000, 'max' => 10000, 'bytestring' => false));
@@ -124,7 +124,7 @@ class Zend_Validate_File_SizeTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_Size(array('min' => 100, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
 
         $validator = new Zend_Validate_File_Size(array('min' => 1, 'max' => 100000));
@@ -187,12 +187,12 @@ class Zend_Validate_File_SizeTest extends \PHPUnit\Framework\TestCase
     {
         $validator = new Zend_Validate_File_Size(array('min' => 9999, 'max' => 10000));
         $this->assertFalse($validator->isValid(dirname(__FILE__) . '/_files/testsize.mo'));
-        $this->assertContains('9.76kB', current($validator->getMessages()));
-        $this->assertContains('794B', current($validator->getMessages()));
+        $this->assertStringContainsString('9.76kB', current($validator->getMessages()));
+        $this->assertStringContainsString('794B', current($validator->getMessages()));
 
         $validator = new Zend_Validate_File_Size(array('min' => 9999, 'max' => 10000, 'bytestring' => false));
         $this->assertFalse($validator->isValid(dirname(__FILE__) . '/_files/testsize.mo'));
-        $this->assertContains('9999', current($validator->getMessages()));
-        $this->assertContains('794', current($validator->getMessages()));
+        $this->assertStringContainsString('9999', current($validator->getMessages()));
+        $this->assertStringContainsString('794', current($validator->getMessages()));
     }
 }

--- a/tests/Zend/Validate/File/UploadTest.php
+++ b/tests/Zend/Validate/File/UploadTest.php
@@ -194,7 +194,7 @@ class Zend_Validate_File_UploadTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals(array(), $validator->getFiles('test5'));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("was not found", $e->getMessage());
+            $this->assertStringContainsString("was not found", $e->getMessage());
         }
     }
 

--- a/tests/Zend/Validate/File/WordCountTest.php
+++ b/tests/Zend/Validate/File/WordCountTest.php
@@ -73,7 +73,7 @@ class Zend_Validate_File_WordCountTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_WordCount(array('min' => 5, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
 
         $validator = new Zend_Validate_File_WordCount(array('min' => 1, 'max' => 5));
@@ -83,7 +83,7 @@ class Zend_Validate_File_WordCountTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_WordCount(array('min' => 5, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
     }
 
@@ -102,7 +102,7 @@ class Zend_Validate_File_WordCountTest extends \PHPUnit\Framework\TestCase
             $validator->setMin(20000);
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("less than or equal", $e->getMessage());
+            $this->assertStringContainsString("less than or equal", $e->getMessage());
         }
     }
 
@@ -120,7 +120,7 @@ class Zend_Validate_File_WordCountTest extends \PHPUnit\Framework\TestCase
             $validator = new Zend_Validate_File_WordCount(array('min' => 5, 'max' => 1));
             $this->fail("Missing exception");
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains("greater than or equal", $e->getMessage());
+            $this->assertStringContainsString("greater than or equal", $e->getMessage());
         }
     }
 

--- a/tests/Zend/Validate/FloatTest.php
+++ b/tests/Zend/Validate/FloatTest.php
@@ -47,7 +47,7 @@ class Zend_Validate_FloatTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_locale = setlocale(LC_ALL, 0); //backup locale
 
@@ -59,7 +59,7 @@ class Zend_Validate_FloatTest extends \PHPUnit\Framework\TestCase
         $this->_validator = new Zend_Validate_Float();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         //restore locale
         if (is_string($this->_locale) && strpos($this->_locale, ';')) {

--- a/tests/Zend/Validate/HexTest.php
+++ b/tests/Zend/Validate/HexTest.php
@@ -48,7 +48,7 @@ class Zend_Validate_HexTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_Hex();
     }

--- a/tests/Zend/Validate/HostnameTest.php
+++ b/tests/Zend/Validate/HostnameTest.php
@@ -48,7 +48,7 @@ class Zend_Validate_HostnameTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_origEncoding = PHP_VERSION_ID < 50600
                     ? iconv_get_encoding('internal_encoding')
@@ -59,7 +59,7 @@ class Zend_Validate_HostnameTest extends \PHPUnit\Framework\TestCase
     /**
      * Reset iconv
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         if (PHP_VERSION_ID < 50600) {
             iconv_set_encoding('internal_encoding', $this->_origEncoding);

--- a/tests/Zend/Validate/IbanTest.php
+++ b/tests/Zend/Validate/IbanTest.php
@@ -62,7 +62,7 @@ class Zend_Validate_IbanTest extends \PHPUnit\Framework\TestCase
             $validator->setLocale('de_QA');
             $this->fail();
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains('IBAN validation', $e->getMessage());
+            $this->assertStringContainsString('IBAN validation', $e->getMessage());
         }
 
         $validator->setLocale('de_DE');

--- a/tests/Zend/Validate/IdenticalTest.php
+++ b/tests/Zend/Validate/IdenticalTest.php
@@ -41,7 +41,7 @@ class Zend_Validate_IdenticalTest extends \PHPUnit\Framework\TestCase
      */
     private $validator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->validator = new Zend_Validate_Identical;
     }

--- a/tests/Zend/Validate/IntTest.php
+++ b/tests/Zend/Validate/IntTest.php
@@ -48,7 +48,7 @@ class Zend_Validate_IntTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_Int();
     }

--- a/tests/Zend/Validate/IpTest.php
+++ b/tests/Zend/Validate/IpTest.php
@@ -47,7 +47,7 @@ class Zend_Validate_IpTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_Ip();
     }
@@ -102,7 +102,7 @@ class Zend_Validate_IpTest extends \PHPUnit\Framework\TestCase
             $this->_validator->setOptions(array('allowipv4' => false, 'allowipv6' => false));
             $this->fail();
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains('Nothing to validate', $e->getMessage());
+            $this->assertStringContainsString('Nothing to validate', $e->getMessage());
         }
     }
 

--- a/tests/Zend/Validate/MessageTest.php
+++ b/tests/Zend/Validate/MessageTest.php
@@ -48,7 +48,7 @@ class Zend_Validate_MessageTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_StringLength(4, 8);
     }

--- a/tests/Zend/Validate/NotEmptyTest.php
+++ b/tests/Zend/Validate/NotEmptyTest.php
@@ -48,7 +48,7 @@ class Zend_Validate_NotEmptyTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_NotEmpty();
     }
@@ -499,7 +499,7 @@ class Zend_Validate_NotEmptyTest extends \PHPUnit\Framework\TestCase
             $this->_validator->setType(true);
             $this->fail();
         } catch (Zend_Exception $e) {
-            $this->assertContains('Unknown', $e->getMessage());
+            $this->assertStringContainsString('Unknown', $e->getMessage());
         }
     }
 
@@ -552,7 +552,7 @@ class Zend_Validate_NotEmptyTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($valid->isValid(''));
         $messages = $valid->getMessages();
         $this->assertTrue(array_key_exists('isEmpty', $messages));
-        $this->assertContains("can't be empty", $messages['isEmpty']);
+        $this->assertStringContainsString("can't be empty", $messages['isEmpty']);
     }
 
     /**

--- a/tests/Zend/Validate/PostCodeTest.php
+++ b/tests/Zend/Validate/PostCodeTest.php
@@ -47,7 +47,7 @@ class Zend_Validate_PostCodeTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_PostCode('de_AT');
     }
@@ -98,7 +98,7 @@ class Zend_Validate_PostCodeTest extends \PHPUnit\Framework\TestCase
             $this->_validator->setLocale('de');
             $this->fail();
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains('Unable to detect a region', $e->getMessage());
+            $this->assertStringContainsString('Unable to detect a region', $e->getMessage());
         }
     }
 
@@ -111,7 +111,7 @@ class Zend_Validate_PostCodeTest extends \PHPUnit\Framework\TestCase
             $this->_validator->setLocale('nus_SD');
             $this->fail();
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains('Unable to detect a postcode format', $e->getMessage());
+            $this->assertStringContainsString('Unable to detect a postcode format', $e->getMessage());
         }
     }
 
@@ -144,14 +144,14 @@ class Zend_Validate_PostCodeTest extends \PHPUnit\Framework\TestCase
             $this->_validator->setFormat(null);
             $this->fail();
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains('A postcode-format string has to be given', $e->getMessage());
+            $this->assertStringContainsString('A postcode-format string has to be given', $e->getMessage());
         }
 
         try {
             $this->_validator->setFormat('');
             $this->fail();
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains('A postcode-format string has to be given', $e->getMessage());
+            $this->assertStringContainsString('A postcode-format string has to be given', $e->getMessage());
         }
     }
 
@@ -162,6 +162,6 @@ class Zend_Validate_PostCodeTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertFalse($this->_validator->isValid('hello'));
         $message = $this->_validator->getMessages();
-        $this->assertContains('not appear to be a postal code', $message['postcodeNoMatch']);
+        $this->assertStringContainsString('not appear to be a postal code', $message['postcodeNoMatch']);
     }
 }

--- a/tests/Zend/Validate/RegexTest.php
+++ b/tests/Zend/Validate/RegexTest.php
@@ -95,7 +95,7 @@ class Zend_Validate_RegexTest extends \PHPUnit\Framework\TestCase
             $validator->isValid('anything');
             $this->fail('Expected Zend_Validate_Exception not thrown for bad pattern');
         } catch (Zend_Validate_Exception $e) {
-            $this->assertContains('Internal error while', $e->getMessage());
+            $this->assertStringContainsString('Internal error while', $e->getMessage());
         }
     }
 

--- a/tests/Zend/Validate/Sitemap/ChangefreqTest.php
+++ b/tests/Zend/Validate/Sitemap/ChangefreqTest.php
@@ -44,7 +44,7 @@ class Zend_Validate_Sitemap_ChangefreqTest extends \PHPUnit\Framework\TestCase
     /**
      * Prepares the environment before running a test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_validator = new Zend_Validate_Sitemap_Changefreq();
     }
@@ -52,7 +52,7 @@ class Zend_Validate_Sitemap_ChangefreqTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleans up the environment after running a test
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->_validator = null;
     }
@@ -88,7 +88,7 @@ class Zend_Validate_Sitemap_ChangefreqTest extends \PHPUnit\Framework\TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('is not a valid', current($messages));
+            $this->assertStringContainsString('is not a valid', current($messages));
         }
     }
 
@@ -105,7 +105,7 @@ class Zend_Validate_Sitemap_ChangefreqTest extends \PHPUnit\Framework\TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('String expected', current($messages));
+            $this->assertStringContainsString('String expected', current($messages));
         }
     }
 }

--- a/tests/Zend/Validate/Sitemap/LastmodTest.php
+++ b/tests/Zend/Validate/Sitemap/LastmodTest.php
@@ -44,7 +44,7 @@ class Zend_Validate_Sitemap_LastmodTest extends \PHPUnit\Framework\TestCase
     /**
      * Prepares the environment before running a test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_validator = new Zend_Validate_Sitemap_Lastmod();
     }
@@ -52,7 +52,7 @@ class Zend_Validate_Sitemap_LastmodTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleans up the environment after running a test
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->_validator = null;
     }
@@ -100,7 +100,7 @@ class Zend_Validate_Sitemap_LastmodTest extends \PHPUnit\Framework\TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('is not a valid', current($messages));
+            $this->assertStringContainsString('is not a valid', current($messages));
         }
     }
 
@@ -117,7 +117,7 @@ class Zend_Validate_Sitemap_LastmodTest extends \PHPUnit\Framework\TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('String expected', current($messages));
+            $this->assertStringContainsString('String expected', current($messages));
         }
     }
 }

--- a/tests/Zend/Validate/Sitemap/LocTest.php
+++ b/tests/Zend/Validate/Sitemap/LocTest.php
@@ -44,7 +44,7 @@ class Zend_Validate_Sitemap_LocTest extends \PHPUnit\Framework\TestCase
     /**
      * Prepares the environment before running a test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_validator = new Zend_Validate_Sitemap_Loc();
     }
@@ -52,7 +52,7 @@ class Zend_Validate_Sitemap_LocTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleans up the environment after running a test
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->_validator = null;
     }
@@ -96,7 +96,7 @@ class Zend_Validate_Sitemap_LocTest extends \PHPUnit\Framework\TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('is not a valid', current($messages));
+            $this->assertStringContainsString('is not a valid', current($messages));
         }
     }
 
@@ -113,7 +113,7 @@ class Zend_Validate_Sitemap_LocTest extends \PHPUnit\Framework\TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('String expected', current($messages));
+            $this->assertStringContainsString('String expected', current($messages));
         }
     }
 

--- a/tests/Zend/Validate/Sitemap/PriorityTest.php
+++ b/tests/Zend/Validate/Sitemap/PriorityTest.php
@@ -44,7 +44,7 @@ class Zend_Validate_Sitemap_PriorityTest extends \PHPUnit\Framework\TestCase
     /**
      * Prepares the environment before running a test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_validator = new Zend_Validate_Sitemap_Priority();
     }
@@ -52,7 +52,7 @@ class Zend_Validate_Sitemap_PriorityTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleans up the environment after running a test
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->_validator = null;
     }
@@ -87,7 +87,7 @@ class Zend_Validate_Sitemap_PriorityTest extends \PHPUnit\Framework\TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('is not a valid', current($messages));
+            $this->assertStringContainsString('is not a valid', current($messages));
         }
     }
 
@@ -104,7 +104,7 @@ class Zend_Validate_Sitemap_PriorityTest extends \PHPUnit\Framework\TestCase
         foreach ($values as $value) {
             $this->assertSame(false, $this->_validator->isValid($value));
             $messages = $this->_validator->getMessages();
-            $this->assertContains('integer or float expected', current($messages));
+            $this->assertStringContainsString('integer or float expected', current($messages));
         }
     }
 }

--- a/tests/Zend/Validate/StringLengthTest.php
+++ b/tests/Zend/Validate/StringLengthTest.php
@@ -47,7 +47,7 @@ class Zend_Validate_StringLengthTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate_StringLength();
     }

--- a/tests/Zend/ValidateTest.php
+++ b/tests/Zend/ValidateTest.php
@@ -57,7 +57,7 @@ class Zend_ValidateTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_validator = new Zend_Validate();
     }
@@ -67,7 +67,7 @@ class Zend_ValidateTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         Zend_Validate::setDefaultNamespaces(array());
     }

--- a/tests/Zend/View/Helper/ActionTest.php
+++ b/tests/Zend/View/Helper/ActionTest.php
@@ -54,7 +54,7 @@ class Zend_View_Helper_ActionTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->_origServer = $_SERVER;
         $_SERVER = array(
@@ -83,7 +83,7 @@ class Zend_View_Helper_ActionTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->request, $this->response, $this->helper);
         $_SERVER = $this->_origServer;
@@ -156,7 +156,7 @@ class Zend_View_Helper_ActionTest extends \PHPUnit\Framework\TestCase
     public function testActionReturnsContentFromDefaultModule()
     {
         $value = $this->helper->action('bar', 'action-foo');
-        $this->assertContains('In default module, FooController::barAction()', $value);
+        $this->assertStringContainsString('In default module, FooController::barAction()', $value);
     }
 
     /**
@@ -165,7 +165,7 @@ class Zend_View_Helper_ActionTest extends \PHPUnit\Framework\TestCase
     public function testActionReturnsContentFromSpecifiedModule()
     {
         $value = $this->helper->action('bar', 'foo', 'foo');
-        $this->assertContains('In foo module, Foo_FooController::barAction()', $value);
+        $this->assertStringContainsString('In foo module, Foo_FooController::barAction()', $value);
     }
 
     /**
@@ -174,8 +174,8 @@ class Zend_View_Helper_ActionTest extends \PHPUnit\Framework\TestCase
     public function testActionReturnsContentReflectingPassedParams()
     {
         $value = $this->helper->action('baz', 'action-foo', null, array('bat' => 'This is my message'));
-        $this->assertNotContains('BOGUS', $value, var_export($this->helper->request->getUserParams(), 1));
-        $this->assertContains('This is my message', $value);
+        $this->assertStringNotContainsString('BOGUS', $value, var_export($this->helper->request->getUserParams(), 1));
+        $this->assertStringContainsString('This is my message', $value);
     }
 
     /**
@@ -249,7 +249,7 @@ class Zend_View_Helper_ActionTest extends \PHPUnit\Framework\TestCase
     public function testViewObjectRemainsUnchangedAfterAction()
     {
         $value = $this->helper->action('bar', 'foo', 'foo');
-        $this->assertContains('In foo module, Foo_FooController::barAction()', $value);
+        $this->assertStringContainsString('In foo module, Foo_FooController::barAction()', $value);
         $this->assertNull($this->view->bar);
     }
 
@@ -257,9 +257,9 @@ class Zend_View_Helper_ActionTest extends \PHPUnit\Framework\TestCase
     {
         $html = $this->helper->action('nest', 'foo', 'foo');
         $title = $this->view->headTitle()->toString();
-        $this->assertContains(' - ', $title, $title);
-        $this->assertContains('Foo Nest', $title);
-        $this->assertContains('Nested Stuff', $title);
+        $this->assertStringContainsString(' - ', $title, $title);
+        $this->assertStringContainsString('Foo Nest', $title);
+        $this->assertStringContainsString('Nested Stuff', $title);
     }
 
     /**

--- a/tests/Zend/View/Helper/AttributeJsEscapingTest.php
+++ b/tests/Zend/View/Helper/AttributeJsEscapingTest.php
@@ -43,7 +43,7 @@ class Zend_View_Helper_AttributeJsEscapingTest extends \PHPUnit\Framework\TestCa
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         if (Zend_Registry::isRegistered('Zend_View_Helper_Doctype')) {
             $registry = Zend_Registry::getInstance();
@@ -60,7 +60,7 @@ class Zend_View_Helper_AttributeJsEscapingTest extends \PHPUnit\Framework\TestCa
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper, $this->view);
     }

--- a/tests/Zend/View/Helper/BaseUrlTest.php
+++ b/tests/Zend/View/Helper/BaseUrlTest.php
@@ -58,7 +58,7 @@ class Zend_View_Helper_BaseUrlTest extends \PHPUnit\Framework\TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_previousBaseUrl = Zend_Controller_Front::getInstance()->getBaseUrl();
         $this->_server = $_SERVER;
@@ -67,7 +67,7 @@ class Zend_View_Helper_BaseUrlTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Zend_Controller_Front::getInstance()->setBaseUrl($this->_previousBaseUrl);
         Zend_Controller_Front::getInstance()->resetInstance();

--- a/tests/Zend/View/Helper/CycleTest.php
+++ b/tests/Zend/View/Helper/CycleTest.php
@@ -47,7 +47,7 @@ class Zend_View_Helper_CycleTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->helper = new Zend_View_Helper_Cycle();
     }
@@ -58,7 +58,7 @@ class Zend_View_Helper_CycleTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }

--- a/tests/Zend/View/Helper/DeclareVarsTest.php
+++ b/tests/Zend/View/Helper/DeclareVarsTest.php
@@ -34,7 +34,7 @@ require_once 'Zend/View/Helper/DeclareVars.php';
  */
 class Zend_View_Helper_DeclareVarsTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $view = new Zend_View();
         $base = str_replace('/', DIRECTORY_SEPARATOR, '/../_templates');
@@ -43,7 +43,7 @@ class Zend_View_Helper_DeclareVarsTest extends \PHPUnit\Framework\TestCase
         $this->view = $view;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->view);
     }

--- a/tests/Zend/View/Helper/DoctypeTest.php
+++ b/tests/Zend/View/Helper/DoctypeTest.php
@@ -55,7 +55,7 @@ class Zend_View_Helper_DoctypeTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $regKey = 'Zend_View_Helper_Doctype';
         if (Zend_Registry::isRegistered($regKey)) {
@@ -71,7 +71,7 @@ class Zend_View_Helper_DoctypeTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }

--- a/tests/Zend/View/Helper/FieldsetTest.php
+++ b/tests/Zend/View/Helper/FieldsetTest.php
@@ -42,7 +42,7 @@ class Zend_View_Helper_FieldsetTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->view   = new Zend_View();
         $this->helper = new Zend_View_Helper_Fieldset();
@@ -56,7 +56,7 @@ class Zend_View_Helper_FieldsetTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         ob_end_clean();
     }
@@ -65,8 +65,8 @@ class Zend_View_Helper_FieldsetTest extends \PHPUnit\Framework\TestCase
     {
         $html = $this->helper->fieldset('foo', 'foobar');
         $this->assertRegexp('#<fieldset[^>]+id="foo".*?>#', $html);
-        $this->assertContains('</fieldset>', $html);
-        $this->assertContains('foobar', $html);
+        $this->assertStringContainsString('</fieldset>', $html);
+        $this->assertStringContainsString('foobar', $html);
     }
 
     public function testProvidingLegendOptionToFieldsetCreatesLegendTag()
@@ -82,7 +82,7 @@ class Zend_View_Helper_FieldsetTest extends \PHPUnit\Framework\TestCase
     {
         foreach (array(null, '', ' ', false) as $legend) {
             $html = $this->helper->fieldset('foo', 'foobar', array('legend' => $legend));
-            $this->assertNotContains('<legend>', $html, 'Failed with value ' . var_export($legend, 1) . ': ' . $html);
+            $this->assertStringNotContainsString('<legend>', $html, 'Failed with value ' . var_export($legend, 1) . ': ' . $html);
         }
     }
 

--- a/tests/Zend/View/Helper/FormButtonTest.php
+++ b/tests/Zend/View/Helper/FormButtonTest.php
@@ -42,7 +42,7 @@ class Zend_View_Helper_FormButtonTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->helper = new Zend_View_Helper_FormButton();
@@ -55,7 +55,7 @@ class Zend_View_Helper_FormButtonTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
     }
 
@@ -65,29 +65,29 @@ class Zend_View_Helper_FormButtonTest extends \PHPUnit\Framework\TestCase
         $this->assertRegexp('/<button[^>]*?value="bar"/', $button);
         $this->assertRegexp('/<button[^>]*?name="foo"/', $button);
         $this->assertRegexp('/<button[^>]*?id="foo"/', $button);
-        $this->assertContains('</button>', $button);
+        $this->assertStringContainsString('</button>', $button);
     }
 
     public function testCanPassContentViaContentAttribKey()
     {
         $button = $this->helper->formButton('foo', 'bar', array('content' => 'Display this'));
-        $this->assertContains('>Display this<', $button);
-        $this->assertContains('<button', $button);
-        $this->assertContains('</button>', $button);
+        $this->assertStringContainsString('>Display this<', $button);
+        $this->assertStringContainsString('<button', $button);
+        $this->assertStringContainsString('</button>', $button);
     }
 
     public function testCanDisableContentEscaping()
     {
         $button = $this->helper->formButton('foo', 'bar', array('content' => '<b>Display this</b>', 'escape' => false));
-        $this->assertContains('><b>Display this</b><', $button);
+        $this->assertStringContainsString('><b>Display this</b><', $button);
 
         $button = $this->helper->formButton(array('name' => 'foo', 'value' => 'bar', 'attribs' => array('content' => '<b>Display this</b>', 'escape' => false)));
-        $this->assertContains('><b>Display this</b><', $button);
+        $this->assertStringContainsString('><b>Display this</b><', $button);
 
         $button = $this->helper->formButton(array('name' => 'foo', 'value' => 'bar', 'escape' => false, 'attribs' => array('content' => '<b>Display this</b>')));
-        $this->assertContains('><b>Display this</b><', $button);
-        $this->assertContains('<button', $button);
-        $this->assertContains('</button>', $button);
+        $this->assertStringContainsString('><b>Display this</b><', $button);
+        $this->assertStringContainsString('<button', $button);
+        $this->assertStringContainsString('</button>', $button);
     }
 
     public function testValueUsedForContentWhenNoContentProvided()
@@ -99,18 +99,18 @@ class Zend_View_Helper_FormButtonTest extends \PHPUnit\Framework\TestCase
     public function testButtonTypeIsButtonByDefault()
     {
         $button = $this->helper->formButton(array('name' => 'foo', 'value' => 'bar'));
-        $this->assertContains('type="button"', $button);
+        $this->assertStringContainsString('type="button"', $button);
     }
 
     public function testButtonTypeMayOnlyBeValidXhtmlButtonType()
     {
         $button = $this->helper->formButton(array('name' => 'foo', 'value' => 'bar', 'attribs' => array('type' => 'submit')));
-        $this->assertContains('type="submit"', $button);
+        $this->assertStringContainsString('type="submit"', $button);
         $button = $this->helper->formButton(array('name' => 'foo', 'value' => 'bar', 'attribs' => array('type' => 'reset')));
-        $this->assertContains('type="reset"', $button);
+        $this->assertStringContainsString('type="reset"', $button);
         $button = $this->helper->formButton(array('name' => 'foo', 'value' => 'bar', 'attribs' => array('type' => 'button')));
-        $this->assertContains('type="button"', $button);
+        $this->assertStringContainsString('type="button"', $button);
         $button = $this->helper->formButton(array('name' => 'foo', 'value' => 'bar', 'attribs' => array('type' => 'bogus')));
-        $this->assertContains('type="button"', $button);
+        $this->assertStringContainsString('type="button"', $button);
     }
 }

--- a/tests/Zend/View/Helper/FormCheckboxTest.php
+++ b/tests/Zend/View/Helper/FormCheckboxTest.php
@@ -39,7 +39,7 @@ require_once 'Zend/Registry.php';
  */
 class Zend_View_Helper_FormCheckboxTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (Zend_Registry::isRegistered('Zend_View_Helper_Doctype')) {
             $registry = Zend_Registry::getInstance();
@@ -53,15 +53,15 @@ class Zend_View_Helper_FormCheckboxTest extends \PHPUnit\Framework\TestCase
     public function testIdSetFromName()
     {
         $element = $this->helper->formCheckbox('foo');
-        $this->assertContains('name="foo"', $element);
-        $this->assertContains('id="foo"', $element);
+        $this->assertStringContainsString('name="foo"', $element);
+        $this->assertStringContainsString('id="foo"', $element);
     }
 
     public function testSetIdFromAttribs()
     {
         $element = $this->helper->formCheckbox('foo', null, array('id' => 'bar'));
-        $this->assertContains('name="foo"', $element);
-        $this->assertContains('id="bar"', $element);
+        $this->assertStringContainsString('name="foo"', $element);
+        $this->assertStringContainsString('id="bar"', $element);
     }
 
     /**
@@ -87,7 +87,7 @@ class Zend_View_Helper_FormCheckboxTest extends \PHPUnit\Framework\TestCase
             'value'  => 'bar',
             'attribs'=> array('disable' => false)
         ));
-        $this->assertNotContains('disabled="disabled"', $html);
+        $this->assertStringNotContainsString('disabled="disabled"', $html);
     }
 
     public function testCanSelectCheckbox()
@@ -186,10 +186,10 @@ class Zend_View_Helper_FormCheckboxTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals(2, count($matches[1]));
             foreach ($matches[1] as $element) {
                 if (strstr($element, 'hidden')) {
-                    $this->assertContains('baz', $element, 'Failed using ' . $html);
+                    $this->assertStringContainsString('baz', $element, 'Failed using ' . $html);
                 } else {
-                    $this->assertContains('bar', $element, 'Failed using ' . $html);
-                    $this->assertContains('checked', $element, 'Failed using ' . $html);
+                    $this->assertStringContainsString('bar', $element, 'Failed using ' . $html);
+                    $this->assertStringContainsString('checked', $element, 'Failed using ' . $html);
                 }
             }
         }
@@ -201,13 +201,13 @@ class Zend_View_Helper_FormCheckboxTest extends \PHPUnit\Framework\TestCase
     public function testCheckedAttributeNotRenderedIfItEvaluatesToFalse()
     {
         $test = $this->helper->formCheckbox('foo', 'value', array('checked' => false));
-        $this->assertNotContains('checked', $test);
+        $this->assertStringNotContainsString('checked', $test);
     }
 
     public function testCanSpecifyValue()
     {
         $test = $this->helper->formCheckbox('foo', 'bar');
-        $this->assertContains('value="bar"', $test);
+        $this->assertStringContainsString('value="bar"', $test);
     }
 
     /**
@@ -216,12 +216,12 @@ class Zend_View_Helper_FormCheckboxTest extends \PHPUnit\Framework\TestCase
     public function testShouldCheckValueIfValueMatchesCheckedOption()
     {
         $test = $this->helper->formCheckbox('foo', 'bar', array(), array('bar', 'baz'));
-        $this->assertContains('value="bar"', $test);
-        $this->assertContains('checked', $test);
+        $this->assertStringContainsString('value="bar"', $test);
+        $this->assertStringContainsString('checked', $test);
 
         $test = $this->helper->formCheckbox('foo', 'bar', array(), array('checked' => 'bar', 'unChecked' => 'baz'));
-        $this->assertContains('value="bar"', $test);
-        $this->assertContains('checked', $test);
+        $this->assertStringContainsString('value="bar"', $test);
+        $this->assertStringContainsString('checked', $test);
     }
 
     /**
@@ -230,7 +230,7 @@ class Zend_View_Helper_FormCheckboxTest extends \PHPUnit\Framework\TestCase
     public function testShouldOnlySetValueIfValueMatchesCheckedOption()
     {
         $test = $this->helper->formCheckbox('foo', 'baz', array(), array('bar', 'baz'));
-        $this->assertContains('value="bar"', $test);
+        $this->assertStringContainsString('value="bar"', $test);
     }
 
     /**
@@ -239,21 +239,21 @@ class Zend_View_Helper_FormCheckboxTest extends \PHPUnit\Framework\TestCase
     public function testShouldNotCheckValueIfValueDoesNotMatchCheckedOption()
     {
         $test = $this->helper->formCheckbox('foo', 'baz', array(), array('bar', 'baz'));
-        $this->assertContains('value="bar"', $test);
-        $this->assertNotContains('checked', $test);
+        $this->assertStringContainsString('value="bar"', $test);
+        $this->assertStringNotContainsString('checked', $test);
     }
 
     public function testRendersAsHtmlByDefault()
     {
         $test = $this->helper->formCheckbox('foo', 'bar');
-        $this->assertNotContains(' />', $test, $test);
+        $this->assertStringNotContainsString(' />', $test, $test);
     }
 
     public function testCanRendersAsXHtml()
     {
         $this->view->doctype('XHTML1_STRICT');
         $test = $this->helper->formCheckbox('foo', 'bar');
-        $this->assertContains(' />', $test);
+        $this->assertStringContainsString(' />', $test);
     }
 
     /**
@@ -262,28 +262,28 @@ class Zend_View_Helper_FormCheckboxTest extends \PHPUnit\Framework\TestCase
     public function testShouldNotShowHiddenFieldIfDisableIsTrue()
     {
         $test = $this->helper->formCheckbox('foo', 'bar', array('disable' => true));
-        $this->assertNotContains('type="hidden"', $test);
+        $this->assertStringNotContainsString('type="hidden"', $test);
     }
 
     public function testIntValueIsChecked()
     {
         $test = $this->helper->formCheckbox('foo', '1', array(), array('checked'=>1, 'unchecked'=>0));
-        $this->assertContains('checked="checked"', $test);
+        $this->assertStringContainsString('checked="checked"', $test);
 
         $test = $this->helper->formCheckbox('foo', '1', array(), array(1,0));
-        $this->assertContains('checked="checked"', $test);
+        $this->assertStringContainsString('checked="checked"', $test);
 
         $test = $this->helper->formCheckbox('foo', 1, array(), array('checked'=>1, 'unchecked'=>0));
-        $this->assertContains('checked="checked"', $test);
+        $this->assertStringContainsString('checked="checked"', $test);
 
         $test = $this->helper->formCheckbox('foo', 1, array(), array(1,0));
-        $this->assertContains('checked="checked"', $test);
+        $this->assertStringContainsString('checked="checked"', $test);
 
         $test = $this->helper->formCheckbox('foo', 0, array(), array('checked'=>1, 'unchecked'=>0));
-        $this->assertNotContains('checked="checked"', $test);
+        $this->assertStringNotContainsString('checked="checked"', $test);
 
         $test = $this->helper->formCheckbox('foo', 0, array(), array(1,0));
-        $this->assertNotContains('checked="checked"', $test);
+        $this->assertStringNotContainsString('checked="checked"', $test);
     }
 
     /**

--- a/tests/Zend/View/Helper/FormErrorsTest.php
+++ b/tests/Zend/View/Helper/FormErrorsTest.php
@@ -42,7 +42,7 @@ class Zend_View_Helper_FormErrorsTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->view   = new Zend_View();
         $this->helper = new Zend_View_Helper_FormErrors();
@@ -56,7 +56,7 @@ class Zend_View_Helper_FormErrorsTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         ob_end_clean();
     }
@@ -101,11 +101,11 @@ class Zend_View_Helper_FormErrorsTest extends \PHPUnit\Framework\TestCase
     {
         $errors = array('foo', 'bar', 'baz');
         $html = $this->helper->formErrors($errors);
-        $this->assertContains('<ul', $html);
+        $this->assertStringContainsString('<ul', $html);
         foreach ($errors as $error) {
-            $this->assertContains('<li>' . $error . '</li>', $html);
+            $this->assertStringContainsString('<li>' . $error . '</li>', $html);
         }
-        $this->assertContains('</ul>', $html);
+        $this->assertStringContainsString('</ul>', $html);
     }
 
     public function testFormErrorsRendersWithSpecifiedStrings()
@@ -115,11 +115,11 @@ class Zend_View_Helper_FormErrorsTest extends \PHPUnit\Framework\TestCase
                      ->setElementEnd('</dt></dl>');
         $errors = array('foo', 'bar', 'baz');
         $html = $this->helper->formErrors($errors);
-        $this->assertContains('<dl>', $html);
+        $this->assertStringContainsString('<dl>', $html);
         foreach ($errors as $error) {
-            $this->assertContains('<dt>' . $error . '</dt>', $html);
+            $this->assertStringContainsString('<dt>' . $error . '</dt>', $html);
         }
-        $this->assertContains('</dl>', $html);
+        $this->assertStringContainsString('</dl>', $html);
     }
 
     public function testFormErrorsPreventsXssAttacks()
@@ -128,8 +128,8 @@ class Zend_View_Helper_FormErrorsTest extends \PHPUnit\Framework\TestCase
             'bad' => '\"><script>alert("xss");</script>',
         );
         $html = $this->helper->formErrors($errors);
-        $this->assertNotContains($errors['bad'], $html);
-        $this->assertContains('&', $html);
+        $this->assertStringNotContainsString($errors['bad'], $html);
+        $this->assertStringContainsString('&', $html);
     }
 
     public function testCanDisableEscapingErrorMessages()
@@ -139,8 +139,8 @@ class Zend_View_Helper_FormErrorsTest extends \PHPUnit\Framework\TestCase
             'bar' => '<a href="/help">Please click here for more information</a>'
         );
         $html = $this->helper->formErrors($errors, array('escape' => false));
-        $this->assertContains($errors['foo'], $html);
-        $this->assertContains($errors['bar'], $html);
+        $this->assertStringContainsString($errors['foo'], $html);
+        $this->assertStringContainsString($errors['bar'], $html);
     }
 
     /**

--- a/tests/Zend/View/Helper/FormFileTest.php
+++ b/tests/Zend/View/Helper/FormFileTest.php
@@ -55,7 +55,7 @@ class Zend_View_Helper_FormFileTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         if (Zend_Registry::isRegistered('Zend_View_Helper_Doctype')) {
             $registry = Zend_Registry::getInstance();
@@ -98,7 +98,7 @@ class Zend_View_Helper_FormFileTest extends \PHPUnit\Framework\TestCase
         $test = $this->helper->formFile(array(
             'name' => 'foo',
         ));
-        $this->assertNotContains(' />', $test);
+        $this->assertStringNotContainsString(' />', $test);
     }
 
     public function testCanRendersAsXHtml()
@@ -107,7 +107,7 @@ class Zend_View_Helper_FormFileTest extends \PHPUnit\Framework\TestCase
         $test = $this->helper->formFile(array(
             'name' => 'foo',
         ));
-        $this->assertContains(' />', $test);
+        $this->assertStringContainsString(' />', $test);
     }
 
     /**

--- a/tests/Zend/View/Helper/FormImageTest.php
+++ b/tests/Zend/View/Helper/FormImageTest.php
@@ -42,7 +42,7 @@ class Zend_View_Helper_FormImageTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->view->doctype('HTML4_LOOSE');  // Reset doctype to default
@@ -57,7 +57,7 @@ class Zend_View_Helper_FormImageTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
     }
 
@@ -86,7 +86,7 @@ class Zend_View_Helper_FormImageTest extends \PHPUnit\Framework\TestCase
         $test = $this->helper->formImage(array(
             'name' => 'foo',
         ));
-        $this->assertNotContains(' />', $test);
+        $this->assertStringNotContainsString(' />', $test);
     }
 
     /**
@@ -98,6 +98,6 @@ class Zend_View_Helper_FormImageTest extends \PHPUnit\Framework\TestCase
         $test = $this->helper->formImage(array(
             'name' => 'foo',
         ));
-        $this->assertContains(' />', $test);
+        $this->assertStringContainsString(' />', $test);
     }
 }

--- a/tests/Zend/View/Helper/FormLabelTest.php
+++ b/tests/Zend/View/Helper/FormLabelTest.php
@@ -43,7 +43,7 @@ class Zend_View_Helper_FormLabelTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->helper = new Zend_View_Helper_FormLabel();
@@ -56,7 +56,7 @@ class Zend_View_Helper_FormLabelTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
     }
 
@@ -98,11 +98,11 @@ class Zend_View_Helper_FormLabelTest extends \PHPUnit\Framework\TestCase
     public function testCanDisableEscapingLabelValue()
     {
         $label = $this->helper->formLabel('foo', '<b>Label This!</b>', array('escape' => false));
-        $this->assertContains('<b>Label This!</b>', $label);
+        $this->assertStringContainsString('<b>Label This!</b>', $label);
         $label = $this->helper->formLabel(array('name' => 'foo', 'value' => '<b>Label This!</b>', 'escape' => false));
-        $this->assertContains('<b>Label This!</b>', $label);
+        $this->assertStringContainsString('<b>Label This!</b>', $label);
         $label = $this->helper->formLabel(array('name' => 'foo', 'value' => '<b>Label This!</b>', 'attribs' => array('escape' => false)));
-        $this->assertContains('<b>Label This!</b>', $label);
+        $this->assertStringContainsString('<b>Label This!</b>', $label);
     }
 
     /**
@@ -111,7 +111,7 @@ class Zend_View_Helper_FormLabelTest extends \PHPUnit\Framework\TestCase
     public function testHelperShouldAllowSuppressionOfForAttribute()
     {
         $label = $this->helper->formLabel('foo', 'bar', array('disableFor' => true));
-        $this->assertNotContains('for="foo"', $label);
+        $this->assertStringNotContainsString('for="foo"', $label);
     }
 
     /**
@@ -120,6 +120,6 @@ class Zend_View_Helper_FormLabelTest extends \PHPUnit\Framework\TestCase
     public function testShouldNotRenderDisableForAttributeIfForIsSuppressed()
     {
         $label = $this->helper->formLabel('foo', 'bar', array('disableFor' => true));
-        $this->assertNotContains('disableFor=', $label, 'Output contains disableFor attribute!');
+        $this->assertStringNotContainsString('disableFor=', $label, 'Output contains disableFor attribute!');
     }
 }

--- a/tests/Zend/View/Helper/FormMultiCheckboxTest.php
+++ b/tests/Zend/View/Helper/FormMultiCheckboxTest.php
@@ -43,7 +43,7 @@ class Zend_View_Helper_FormMultiCheckboxTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         if (Zend_Registry::isRegistered('Zend_View_Helper_Doctype')) {
             $registry = Zend_Registry::getInstance();
@@ -61,7 +61,7 @@ class Zend_View_Helper_FormMultiCheckboxTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         ob_end_clean();
     }
@@ -83,10 +83,10 @@ class Zend_View_Helper_FormMultiCheckboxTest extends \PHPUnit\Framework\TestCase
             if (!preg_match($pattern, $html, $matches)) {
                 $this->fail('Failed to match ' . $pattern . ': ' . $html);
             }
-            $this->assertContains($value, $matches[5], var_export($matches, 1));
-            $this->assertContains('type="checkbox"', $matches[3], var_export($matches, 1));
-            $this->assertContains('name="foo[]"', $matches[3], var_export($matches, 1));
-            $this->assertContains('value="' . $key . '"', $matches[3], var_export($matches, 1));
+            $this->assertStringContainsString($value, $matches[5], var_export($matches, 1));
+            $this->assertStringContainsString('type="checkbox"', $matches[3], var_export($matches, 1));
+            $this->assertStringContainsString('name="foo[]"', $matches[3], var_export($matches, 1));
+            $this->assertStringContainsString('value="' . $key . '"', $matches[3], var_export($matches, 1));
         }
     }
 
@@ -107,7 +107,7 @@ class Zend_View_Helper_FormMultiCheckboxTest extends \PHPUnit\Framework\TestCase
             if (!preg_match($pattern, $html, $matches)) {
                 $this->fail('Failed to match ' . $pattern . ': ' . $html);
             }
-            $this->assertNotContains(' />', $matches[1]);
+            $this->assertStringNotContainsString(' />', $matches[1]);
         }
     }
 
@@ -129,7 +129,7 @@ class Zend_View_Helper_FormMultiCheckboxTest extends \PHPUnit\Framework\TestCase
             if (!preg_match($pattern, $html, $matches)) {
                 $this->fail('Failed to match ' . $pattern . ': ' . $html);
             }
-            $this->assertContains(' />', $matches[1]);
+            $this->assertStringContainsString(' />', $matches[1]);
         }
     }
 }

--- a/tests/Zend/View/Helper/FormPasswordTest.php
+++ b/tests/Zend/View/Helper/FormPasswordTest.php
@@ -45,7 +45,7 @@ class Zend_View_Helper_FormPasswordTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         if (Zend_Registry::isRegistered('Zend_View_Helper_Doctype')) {
             $registry = Zend_Registry::getInstance();
@@ -87,20 +87,20 @@ class Zend_View_Helper_FormPasswordTest extends \PHPUnit\Framework\TestCase
     public function testShouldRenderAsHtmlByDefault()
     {
         $test = $this->helper->formPassword('foo', 'bar');
-        $this->assertNotContains(' />', $test);
+        $this->assertStringNotContainsString(' />', $test);
     }
 
     public function testShouldAllowRenderingAsXhtml()
     {
         $this->view->doctype('XHTML1_STRICT');
         $test = $this->helper->formPassword('foo', 'bar');
-        $this->assertContains(' />', $test);
+        $this->assertStringContainsString(' />', $test);
     }
 
     public function testShouldNotRenderValueByDefault()
     {
         $test = $this->helper->formPassword('foo', 'bar');
-        $this->assertNotContains('bar', $test);
+        $this->assertStringNotContainsString('bar', $test);
     }
 
     /**
@@ -109,7 +109,7 @@ class Zend_View_Helper_FormPasswordTest extends \PHPUnit\Framework\TestCase
     public function testShouldRenderValueWhenRenderPasswordFlagPresentAndTrue()
     {
         $test = $this->helper->formPassword('foo', 'bar', array('renderPassword' => true));
-        $this->assertContains('value="bar"', $test);
+        $this->assertStringContainsString('value="bar"', $test);
     }
 
     /**
@@ -118,8 +118,8 @@ class Zend_View_Helper_FormPasswordTest extends \PHPUnit\Framework\TestCase
     public function testRenderPasswordAttribShouldNeverBeRendered()
     {
         $test = $this->helper->formPassword('foo', 'bar', array('renderPassword' => true));
-        $this->assertNotContains('renderPassword', $test);
+        $this->assertStringNotContainsString('renderPassword', $test);
         $test = $this->helper->formPassword('foo', 'bar', array('renderPassword' => false));
-        $this->assertNotContains('renderPassword', $test);
+        $this->assertStringNotContainsString('renderPassword', $test);
     }
 }

--- a/tests/Zend/View/Helper/FormRadioTest.php
+++ b/tests/Zend/View/Helper/FormRadioTest.php
@@ -38,7 +38,7 @@ require_once 'Zend/View.php';
  */
 class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->view   = new Zend_View();
         $this->view->doctype('HTML4_LOOSE'); // Set default doctype
@@ -145,7 +145,7 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
             'listsep' => '--FunkySep--',
         ));
 
-        $this->assertContains('--FunkySep--', $html);
+        $this->assertStringContainsString('--FunkySep--', $html);
         $count = substr_count($html, '--FunkySep--');
         $this->assertEquals(2, $count);
     }
@@ -229,8 +229,8 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
             'options' => $options,
         ));
 
-        $this->assertNotContains($options['bar'], $html);
-        $this->assertContains('&lt;b&gt;Bar&lt;/b&gt;', $html);
+        $this->assertStringNotContainsString($options['bar'], $html);
+        $this->assertStringContainsString('&lt;b&gt;Bar&lt;/b&gt;', $html);
     }
 
     public function testXhtmlLabelsAreAllowed()
@@ -244,7 +244,7 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
             'attribs' => array('escape' => false)
         ));
 
-        $this->assertContains($options['bar'], $html);
+        $this->assertStringContainsString($options['bar'], $html);
     }
 
     /**
@@ -281,7 +281,7 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
         if (!preg_match('/(<input[^>]*?(value="bar")[^>]*>)/', $html, $matches)) {
             $this->fail('Radio for a given option was not found?');
         }
-        $this->assertContains('checked="checked"', $matches[1], var_export($matches, 1));
+        $this->assertStringContainsString('checked="checked"', $matches[1], var_export($matches, 1));
     }
 
     public function testOptionsWithMatchesInAnArrayOfValuesAreChecked()
@@ -301,7 +301,7 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
             if (!preg_match('/(<input[^>]*?(value="' . $value . '")[^>]*>)/', $html, $matches)) {
                 $this->fail('Radio for a given option was not found?');
             }
-            $this->assertContains('checked="checked"', $matches[1], var_export($matches, 1));
+            $this->assertStringContainsString('checked="checked"', $matches[1], var_export($matches, 1));
         }
     }
 
@@ -363,7 +363,7 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
             'value'   => 'bar',
             'options' => $options,
         ));
-        $this->assertNotContains('style="white-space: nowrap;"', $html);
+        $this->assertStringNotContainsString('style="white-space: nowrap;"', $html);
     }
 
     /**
@@ -427,9 +427,9 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
             'options' => $options,
         ));
 
-        $this->assertContains('value="foo">', $html);
-        $this->assertContains('value="bar">', $html);
-        $this->assertContains('value="baz">', $html);
+        $this->assertStringContainsString('value="foo">', $html);
+        $this->assertStringContainsString('value="bar">', $html);
+        $this->assertStringContainsString('value="baz">', $html);
     }
 
     /**
@@ -447,9 +447,9 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
             'name'    => 'foo',
             'options' => $options,
         ));
-        $this->assertContains('value="foo" />', $html);
-        $this->assertContains('value="bar" />', $html);
-        $this->assertContains('value="baz" />', $html);
+        $this->assertStringContainsString('value="foo" />', $html);
+        $this->assertStringContainsString('value="bar" />', $html);
+        $this->assertStringContainsString('value="baz" />', $html);
     }
 
      /**
@@ -469,7 +469,7 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
              'options' => $options,
          ));
 
-         $this->assertContains('<br />', $html);
+         $this->assertStringContainsString('<br />', $html);
          $count = substr_count($html, '<br />');
          $this->assertEquals(2, $count);
      }
@@ -491,7 +491,7 @@ class Zend_View_Helper_FormRadioTest extends \PHPUnit\Framework\TestCase
              'options' => $options,
          ));
 
-         $this->assertContains('<br>', $html);
+         $this->assertStringContainsString('<br>', $html);
          $count = substr_count($html, '<br>');
          $this->assertEquals(2, $count);
      }

--- a/tests/Zend/View/Helper/FormResetTest.php
+++ b/tests/Zend/View/Helper/FormResetTest.php
@@ -43,7 +43,7 @@ class Zend_View_Helper_FormResetTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         if (Zend_Registry::isRegistered('Zend_View_Helper_Doctype')) {
             $registry = Zend_Registry::getInstance();
@@ -60,7 +60,7 @@ class Zend_View_Helper_FormResetTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper, $this->view);
     }
@@ -90,13 +90,13 @@ class Zend_View_Helper_FormResetTest extends \PHPUnit\Framework\TestCase
     public function testShouldRenderAsHtmlByDefault()
     {
         $test = $this->helper->formReset('foo', 'bar');
-        $this->assertNotContains(' />', $test);
+        $this->assertStringNotContainsString(' />', $test);
     }
 
     public function testShouldAllowRenderingAsXHtml()
     {
         $this->view->doctype('XHTML1_STRICT');
         $test = $this->helper->formReset('foo', 'bar');
-        $this->assertContains(' />', $test);
+        $this->assertStringContainsString(' />', $test);
     }
 }

--- a/tests/Zend/View/Helper/FormSelectTest.php
+++ b/tests/Zend/View/Helper/FormSelectTest.php
@@ -42,7 +42,7 @@ class Zend_View_Helper_FormSelectTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->view   = new Zend_View();
         $this->helper = new Zend_View_Helper_FormSelect();
@@ -55,7 +55,7 @@ class Zend_View_Helper_FormSelectTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper, $this->view);
     }
@@ -90,15 +90,15 @@ class Zend_View_Helper_FormSelectTest extends \PHPUnit\Framework\TestCase
     {
         $html = $this->helper->formSelect('foo');
         $this->assertRegExp('#<select[^>]+name="foo"#', $html);
-        $this->assertContains('</select>', $html);
-        $this->assertNotContains('<option', $html);
+        $this->assertStringContainsString('</select>', $html);
+        $this->assertStringNotContainsString('<option', $html);
     }
 
     public function testFormSelectWithOptionsCreatesPopulatedSelect()
     {
         $html = $this->helper->formSelect('foo', null, null, array('foo' => 'Foobar', 'baz' => 'Bazbat'));
         $this->assertRegExp('#<select[^>]+name="foo"#', $html);
-        $this->assertContains('</select>', $html);
+        $this->assertStringContainsString('</select>', $html);
         $this->assertRegExp('#<option[^>]+value="foo".*?>Foobar</option>#', $html);
         $this->assertRegExp('#<option[^>]+value="baz".*?>Bazbat</option>#', $html);
         $this->assertEquals(2, substr_count($html, '<option'));

--- a/tests/Zend/View/Helper/FormSubmitTest.php
+++ b/tests/Zend/View/Helper/FormSubmitTest.php
@@ -43,7 +43,7 @@ class Zend_View_Helper_FormSubmitTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         if (Zend_Registry::isRegistered('Zend_View_Helper_Doctype')) {
             $registry = Zend_Registry::getInstance();
@@ -60,7 +60,7 @@ class Zend_View_Helper_FormSubmitTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper, $this->view);
     }
@@ -102,14 +102,14 @@ class Zend_View_Helper_FormSubmitTest extends \PHPUnit\Framework\TestCase
     public function testRendersAsHtmlByDefault()
     {
         $test = $this->helper->formSubmit('foo', 'bar');
-        $this->assertNotContains(' />', $test);
+        $this->assertStringNotContainsString(' />', $test);
     }
 
     public function testCanRendersAsXHtml()
     {
         $this->view->doctype('XHTML1_STRICT');
         $test = $this->helper->formSubmit('foo', 'bar');
-        $this->assertContains(' />', $test);
+        $this->assertStringContainsString(' />', $test);
     }
 
     /**
@@ -118,6 +118,6 @@ class Zend_View_Helper_FormSubmitTest extends \PHPUnit\Framework\TestCase
     public function testDoesNotOutputEmptyId()
     {
         $test = $this->helper->formSubmit('', 'bar');
-        $this->assertNotContains('id=""', $test);
+        $this->assertStringNotContainsString('id=""', $test);
     }
 }

--- a/tests/Zend/View/Helper/FormTest.php
+++ b/tests/Zend/View/Helper/FormTest.php
@@ -42,7 +42,7 @@ class Zend_View_Helper_FormTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->helper = new Zend_View_Helper_Form();
@@ -55,7 +55,7 @@ class Zend_View_Helper_FormTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
     }
 
@@ -70,7 +70,7 @@ class Zend_View_Helper_FormTest extends \PHPUnit\Framework\TestCase
     public function testFormWithInputNeedingEscapesUsesViewEscaping()
     {
         $form = $this->helper->form('<&foo');
-        $this->assertContains($this->view->escape('<&foo'), $form);
+        $this->assertStringContainsString($this->view->escape('<&foo'), $form);
     }
 
     /**

--- a/tests/Zend/View/Helper/FormTextTest.php
+++ b/tests/Zend/View/Helper/FormTextTest.php
@@ -44,7 +44,7 @@ class Zend_View_Helper_FormTextTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         if (Zend_Registry::isRegistered('Zend_View_Helper_Doctype')) {
             $registry = Zend_Registry::getInstance();
@@ -58,28 +58,28 @@ class Zend_View_Helper_FormTextTest extends \PHPUnit\Framework\TestCase
     public function testIdSetFromName()
     {
         $element = $this->helper->formText('foo');
-        $this->assertContains('name="foo"', $element);
-        $this->assertContains('id="foo"', $element);
+        $this->assertStringContainsString('name="foo"', $element);
+        $this->assertStringContainsString('id="foo"', $element);
     }
 
     public function testSetIdFromAttribs()
     {
         $element = $this->helper->formText('foo', null, array('id' => 'bar'));
-        $this->assertContains('name="foo"', $element);
-        $this->assertContains('id="bar"', $element);
+        $this->assertStringContainsString('name="foo"', $element);
+        $this->assertStringContainsString('id="bar"', $element);
     }
 
     public function testSetValue()
     {
         $element = $this->helper->formText('foo', 'bar');
-        $this->assertContains('name="foo"', $element);
-        $this->assertContains('value="bar"', $element);
+        $this->assertStringContainsString('name="foo"', $element);
+        $this->assertStringContainsString('value="bar"', $element);
     }
 
     public function testReadOnlyAttribute()
     {
         $element = $this->helper->formText('foo', null, array('readonly' => 'readonly'));
-        $this->assertContains('readonly="readonly"', $element);
+        $this->assertStringContainsString('readonly="readonly"', $element);
     }
 
     /**
@@ -113,13 +113,13 @@ class Zend_View_Helper_FormTextTest extends \PHPUnit\Framework\TestCase
     public function testRendersAsHtmlByDefault()
     {
         $test = $this->helper->formText('foo', 'bar');
-        $this->assertNotContains(' />', $test);
+        $this->assertStringNotContainsString(' />', $test);
     }
 
     public function testCanRendersAsXHtml()
     {
         $this->view->doctype('XHTML1_STRICT');
         $test = $this->helper->formText('foo', 'bar');
-        $this->assertContains(' />', $test);
+        $this->assertStringContainsString(' />', $test);
     }
 }

--- a/tests/Zend/View/Helper/FormTextareaTest.php
+++ b/tests/Zend/View/Helper/FormTextareaTest.php
@@ -46,7 +46,7 @@ class Zend_View_Helper_FormTextareaTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->helper = new Zend_View_Helper_FormTextarea();

--- a/tests/Zend/View/Helper/GravatarTest.php
+++ b/tests/Zend/View/Helper/GravatarTest.php
@@ -54,7 +54,7 @@ class Zend_View_Helper_GravatarTest extends \PHPUnit\Framework\TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_object = new Zend_View_Helper_Gravatar();
         $this->_view   = new Zend_View();
@@ -69,7 +69,7 @@ class Zend_View_Helper_GravatarTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         unset($this->_object, $this->_view);
     }

--- a/tests/Zend/View/Helper/HeadLinkTest.php
+++ b/tests/Zend/View/Helper/HeadLinkTest.php
@@ -61,7 +61,7 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         foreach (array(Zend_View_Helper_Placeholder_Registry::REGISTRY_KEY, 'Zend_View_Helper_Doctype') as $key) {
             if (Zend_Registry::isRegistered($key)) {
@@ -81,7 +81,7 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -158,11 +158,11 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
 
         foreach ($links as $link) {
             $substr = ' href="' . $link['href'] . '"';
-            $this->assertContains($substr, $string);
+            $this->assertStringContainsString($substr, $string);
             $substr = ' rel="' . $link['rel'] . '"';
-            $this->assertContains($substr, $string);
+            $this->assertStringContainsString($substr, $string);
             $substr = ' type="' . $link['type'] . '"';
-            $this->assertContains($substr, $string);
+            $this->assertStringContainsString($substr, $string);
         }
 
         $order = array();
@@ -194,11 +194,11 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
 
         foreach ($links as $link) {
             $substr = ' href="' . $link['href'] . '"';
-            $this->assertContains($substr, $string);
+            $this->assertStringContainsString($substr, $string);
             $substr = ' rel="' . $link['rel'] . '"';
-            $this->assertContains($substr, $string);
+            $this->assertStringContainsString($substr, $string);
             $substr = ' type="' . $link['type'] . '"';
-            $this->assertContains($substr, $string);
+            $this->assertStringContainsString($substr, $string);
         }
 
         $order = array();
@@ -235,11 +235,11 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
 
         foreach ($links as $link) {
             $substr = ' href="' . $link['href'] . '"';
-            $this->assertContains($substr, $string);
+            $this->assertStringContainsString($substr, $string);
             $substr = ' title="' . $link['title'] . '"';
-            $this->assertContains($substr, $string);
+            $this->assertStringContainsString($substr, $string);
             $substr = ' type="' . $link['type'] . '"';
-            $this->assertContains($substr, $string);
+            $this->assertStringContainsString($substr, $string);
         }
 
         $order = array();
@@ -311,10 +311,10 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($item->conditionalStylesheet);
 
         $string = $this->helper->toString();
-        $this->assertContains('/styles.css', $string);
-        $this->assertNotContains('<!--[if', $string);
-        $this->assertNotContains(']>', $string);
-        $this->assertNotContains('<![endif]-->', $string);
+        $this->assertStringContainsString('/styles.css', $string);
+        $this->assertStringNotContainsString('<!--[if', $string);
+        $this->assertStringNotContainsString(']>', $string);
+        $this->assertStringNotContainsString('<![endif]-->', $string);
     }
 
     public function testConditionalStylesheetCreationOccursWhenRequested()
@@ -325,9 +325,9 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('ie6', $item->conditionalStylesheet);
 
         $string = $this->helper->toString();
-        $this->assertContains('/styles.css', $string);
-        $this->assertContains('<!--[if ie6]>', $string);
-        $this->assertContains('<![endif]-->', $string);
+        $this->assertStringContainsString('/styles.css', $string);
+        $this->assertStringContainsString('<!--[if ie6]>', $string);
+        $this->assertStringContainsString('<![endif]-->', $string);
     }
 
     public function testSettingAlternateWithTooFewArgsRaisesException()
@@ -359,7 +359,7 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
         $this->helper->headLink(array('rel' => 'icon', 'src' => '/foo/bar'))
                      ->headLink(array('rel' => 'foo', 'href' => '/bar/baz'));
         $test = $this->helper->toString();
-        $this->assertNotContains(' />', $test);
+        $this->assertStringNotContainsString(' />', $test);
     }
 
     public function testDoesNotAllowDuplicateStylesheets()
@@ -376,7 +376,7 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
     {
         $this->helper->appendStylesheet(array('href' => '/bar/baz', 'conditionalStylesheet' => false));
         $test = $this->helper->toString();
-        $this->assertNotContains('[if false]', $test);
+        $this->assertStringNotContainsString('[if false]', $test);
     }
 
     /**
@@ -387,8 +387,8 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
     {
         $this->helper->appendStylesheet(array('href' => '/bar/baz', 'conditionalStylesheet' => true));
         $test = $this->helper->toString();
-        $this->assertNotContains('[if 1]', $test);
-        $this->assertNotContains('[if true]', $test);
+        $this->assertStringNotContainsString('[if 1]', $test);
+        $this->assertStringNotContainsString('[if true]', $test);
     }
 
     /**
@@ -398,28 +398,28 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
     public function testTurnOffAutoEscapeDoesNotEncodeAmpersand()
     {
         $this->helper->setAutoEscape(false)->appendStylesheet('/css/rules.css?id=123&foo=bar');
-        $this->assertContains('id=123&foo=bar', $this->helper->toString());
+        $this->assertStringContainsString('id=123&foo=bar', $this->helper->toString());
     }
 
     public function testSetAlternateWithExtras()
     {
         $this->helper->setAlternate('/mydocument.pdf', 'application/pdf', 'foo', array('media' => array('print','screen')));
         $test = $this->helper->toString();
-        $this->assertContains('media="print,screen"', $test);
+        $this->assertStringContainsString('media="print,screen"', $test);
     }
 
     public function testAppendStylesheetWithExtras()
     {
         $this->helper->appendStylesheet(array('href' => '/bar/baz', 'conditionalStylesheet' => false, 'extras' => array('id' => 'my_link_tag')));
         $test = $this->helper->toString();
-        $this->assertContains('id="my_link_tag"', $test);
+        $this->assertStringContainsString('id="my_link_tag"', $test);
     }
 
     public function testSetStylesheetWithMediaAsArray()
     {
         $this->helper->appendStylesheet('/bar/baz', array('screen','print'));
         $test = $this->helper->toString();
-        $this->assertContains(' media="screen,print"', $test);
+        $this->assertStringContainsString(' media="screen,print"', $test);
     }
 
     /**
@@ -448,7 +448,7 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
     public function testIdAttributeIsSupported()
     {
         $this->helper->appendStylesheet(array('href' => '/bar/baz', 'id' => 'foo'));
-        $this->assertContains('id="foo"', $this->helper->toString());
+        $this->assertStringContainsString('id="foo"', $this->helper->toString());
     }
 
     /**
@@ -458,7 +458,7 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
     {
         $this->helper->appendStylesheet('/css/auth.less', 'all', null, array('rel' => 'stylesheet/less'));
         $this->assertEquals(1, substr_count($this->helper->toString(), "rel=\""));
-        $this->assertContains('rel="stylesheet/less"', $this->helper->toString());
+        $this->assertStringContainsString('rel="stylesheet/less"', $this->helper->toString());
     }
 
     /**
@@ -490,9 +490,9 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
         $this->assertObjectHasAttribute('conditionalStylesheet', $item);
         $this->assertEquals('!IE', $item->conditionalStylesheet);
         $string = $this->helper->toString();
-        $this->assertContains('/styles.css', $string);
-        $this->assertContains('<!--[if !IE]><!--><', $string);
-        $this->assertContains('<!--<![endif]-->', $string);
+        $this->assertStringContainsString('/styles.css', $string);
+        $this->assertStringContainsString('<!--[if !IE]><!--><', $string);
+        $this->assertStringContainsString('<!--<![endif]-->', $string);
     }
 
     /**
@@ -505,8 +505,8 @@ class Zend_View_Helper_HeadLinkTest extends \PHPUnit\Framework\TestCase
         $this->assertObjectHasAttribute('conditionalStylesheet', $item);
         $this->assertEquals('! IE', $item->conditionalStylesheet);
         $string = $this->helper->toString();
-        $this->assertContains('/styles.css', $string);
-        $this->assertContains('<!--[if ! IE]><!--><', $string);
-        $this->assertContains('<!--<![endif]-->', $string);
+        $this->assertStringContainsString('/styles.css', $string);
+        $this->assertStringContainsString('<!--[if ! IE]><!--><', $string);
+        $this->assertStringContainsString('<!--<![endif]-->', $string);
     }
 }

--- a/tests/Zend/View/Helper/HeadMetaTest.php
+++ b/tests/Zend/View/Helper/HeadMetaTest.php
@@ -61,7 +61,7 @@ class Zend_View_Helper_HeadMetaTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->error = false;
         foreach (array(Zend_View_Helper_Placeholder_Registry::REGISTRY_KEY, 'Zend_View_Helper_Doctype') as $key) {
@@ -83,7 +83,7 @@ class Zend_View_Helper_HeadMetaTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -281,13 +281,13 @@ class Zend_View_Helper_HeadMetaTest extends \PHPUnit\Framework\TestCase
         $metas = substr_count($string, 'http-equiv="');
         $this->assertEquals(1, $metas);
 
-        $this->assertContains('http-equiv="screen" content="projection"', $string);
-        $this->assertContains('name="keywords" content="foo bar"', $string);
-        $this->assertContains('lang="us_en"', $string);
-        $this->assertContains('scheme="foo"', $string);
-        $this->assertNotContains('bogus', $string);
-        $this->assertNotContains('unused', $string);
-        $this->assertContains('name="title" content="boo bah"', $string);
+        $this->assertStringContainsString('http-equiv="screen" content="projection"', $string);
+        $this->assertStringContainsString('name="keywords" content="foo bar"', $string);
+        $this->assertStringContainsString('lang="us_en"', $string);
+        $this->assertStringContainsString('scheme="foo"', $string);
+        $this->assertStringNotContainsString('bogus', $string);
+        $this->assertStringNotContainsString('unused', $string);
+        $this->assertStringContainsString('name="title" content="boo bah"', $string);
     }
 
     /**
@@ -341,9 +341,9 @@ class Zend_View_Helper_HeadMetaTest extends \PHPUnit\Framework\TestCase
         $this->view->doctype('HTML4_STRICT');
         $this->helper->headMeta('some content', 'foo');
         $test = $this->helper->toString();
-        $this->assertNotContains('/>', $test);
-        $this->assertContains('some content', $test);
-        $this->assertContains('foo', $test);
+        $this->assertStringNotContainsString('/>', $test);
+        $this->assertStringContainsString('some content', $test);
+        $this->assertStringContainsString('foo', $test);
     }
 
     /**
@@ -367,7 +367,7 @@ class Zend_View_Helper_HeadMetaTest extends \PHPUnit\Framework\TestCase
             $this->helper->headMeta('foo', 'og:title', 'property');
             $this->fail('meta property attribute should not be supported on default doctype');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('Invalid value passed', $e->getMessage());
+            $this->assertStringContainsString('Invalid value passed', $e->getMessage());
         }
     }
 
@@ -534,8 +534,8 @@ class Zend_View_Helper_HeadMetaTest extends \PHPUnit\Framework\TestCase
     public function testConditionalNoIE()
     {
         $html = $this->helper->appendHttpEquiv('foo', 'bar', array('conditional' => '!IE'))->toString();
-        $this->assertContains('<!--[if !IE]><!--><', $html);
-        $this->assertContains('<!--<![endif]-->', $html);
+        $this->assertStringContainsString('<!--[if !IE]><!--><', $html);
+        $this->assertStringContainsString('<!--<![endif]-->', $html);
     }
 
     /**
@@ -544,7 +544,7 @@ class Zend_View_Helper_HeadMetaTest extends \PHPUnit\Framework\TestCase
     public function testConditionalNoIEWidthSpace()
     {
         $html = $this->helper->appendHttpEquiv('foo', 'bar', array('conditional' => '! IE'))->toString();
-        $this->assertContains('<!--[if ! IE]><!--><', $html);
-        $this->assertContains('<!--<![endif]-->', $html);
+        $this->assertStringContainsString('<!--[if ! IE]><!--><', $html);
+        $this->assertStringContainsString('<!--<![endif]-->', $html);
     }
 }

--- a/tests/Zend/View/Helper/HeadScriptTest.php
+++ b/tests/Zend/View/Helper/HeadScriptTest.php
@@ -58,7 +58,7 @@ class Zend_View_Helper_HeadScriptTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $regKey = Zend_View_Helper_Placeholder_Registry::REGISTRY_KEY;
         if (Zend_Registry::isRegistered($regKey)) {
@@ -75,7 +75,7 @@ class Zend_View_Helper_HeadScriptTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -299,9 +299,9 @@ class Zend_View_Helper_HeadScriptTest extends \PHPUnit\Framework\TestCase
         $scripts = substr_count($string, '><');
         $this->assertEquals(1, $scripts);
 
-        $this->assertContains('src="foo"', $string);
-        $this->assertContains('bar', $string);
-        $this->assertContains('baz', $string);
+        $this->assertStringContainsString('src="foo"', $string);
+        $this->assertStringContainsString('bar', $string);
+        $this->assertStringContainsString('baz', $string);
 
         $doc = new DOMDocument;
         $dom = $doc->loadHtml($string);
@@ -316,7 +316,7 @@ class Zend_View_Helper_HeadScriptTest extends \PHPUnit\Framework\TestCase
         $values = $this->helper->getArrayCopy();
         $this->assertEquals(1, count($values), var_export($values, 1));
         $item = array_shift($values);
-        $this->assertContains('foobar', $item->source);
+        $this->assertStringContainsString('foobar', $item->source);
     }
 
     public function testIndentationIsHonored()
@@ -332,10 +332,10 @@ document.write(bar.strlen());');
 
         $scripts = substr_count($string, '    <script');
         $this->assertEquals(2, $scripts);
-        $this->assertContains('    //', $string);
-        $this->assertContains('var', $string);
-        $this->assertContains('document', $string);
-        $this->assertContains('    document', $string);
+        $this->assertStringContainsString('    //', $string);
+        $this->assertStringContainsString('var', $string);
+        $this->assertStringContainsString('document', $string);
+        $this->assertStringContainsString('    document', $string);
     }
 
     public function testDoesNotAllowDuplicateFiles()
@@ -349,7 +349,7 @@ document.write(bar.strlen());');
     {
         $this->helper->headScript()->appendFile('/js/foo.js', 'text/javascript', array('bogus' => 'deferred'));
         $test = $this->helper->headScript()->toString();
-        $this->assertNotContains('bogus="deferred"', $test);
+        $this->assertStringNotContainsString('bogus="deferred"', $test);
     }
 
     public function testCanRenderArbitraryAttributesOnRequest()
@@ -357,7 +357,7 @@ document.write(bar.strlen());');
         $this->helper->headScript()->appendFile('/js/foo.js', 'text/javascript', array('bogus' => 'deferred'))
              ->setAllowArbitraryAttributes(true);
         $test = $this->helper->headScript()->toString();
-        $this->assertContains('bogus="deferred"', $test);
+        $this->assertStringContainsString('bogus="deferred"', $test);
     }
 
     public function testCanPerformMultipleSerialCaptures()
@@ -384,7 +384,7 @@ document.write(bar.strlen());');
             $this->fail('Should not be able to nest captures');
         } catch (Zend_View_Exception $e) {
             $this->helper->headScript()->captureEnd();
-            $this->assertContains('Cannot nest', $e->getMessage());
+            $this->assertStringContainsString('Cannot nest', $e->getMessage());
         }
     }
 
@@ -402,7 +402,7 @@ document.write(bar.strlen());');
     {
         $this->helper->headScript()->appendFile('/js/foo.js', 'text/javascript', array('conditional' => 'lt IE 7'));
         $test = $this->helper->headScript()->toString();
-        $this->assertContains('<!--[if lt IE 7]>', $test);
+        $this->assertStringContainsString('<!--[if lt IE 7]>', $test);
     }
 
     public function testConditionalScriptWidthIndentation()
@@ -410,7 +410,7 @@ document.write(bar.strlen());');
         $this->helper->headScript()->appendFile('/js/foo.js', 'text/javascript', array('conditional' => 'lt IE 7'));
         $this->helper->headScript()->setIndent(4);
         $test = $this->helper->headScript()->toString();
-        $this->assertContains('    <!--[if lt IE 7]>', $test);
+        $this->assertStringContainsString('    <!--[if lt IE 7]>', $test);
     }
 
     /**
@@ -460,7 +460,7 @@ document.write(bar.strlen());');
         );
         $test = $this->helper->toString();
 
-        $this->assertNotContains('conditional', $test);
+        $this->assertStringNotContainsString('conditional', $test);
     }
 
     /**
@@ -474,7 +474,7 @@ document.write(bar.strlen());');
         );
         $test = $this->helper->toString();
 
-        $this->assertNotContains('noescape', $test);
+        $this->assertStringNotContainsString('noescape', $test);
     }
 
     /**
@@ -487,8 +487,8 @@ document.write(bar.strlen());');
         );
         $test = $this->helper->toString();
 
-        $this->assertContains('//<!--', $test);
-        $this->assertContains('//-->', $test);
+        $this->assertStringContainsString('//<!--', $test);
+        $this->assertStringContainsString('//-->', $test);
     }
 
     /**
@@ -501,8 +501,8 @@ document.write(bar.strlen());');
         );
         $test = $this->helper->toString();
 
-        $this->assertNotContains('//<!--', $test);
-        $this->assertNotContains('//-->', $test);
+        $this->assertStringNotContainsString('//<!--', $test);
+        $this->assertStringNotContainsString('//-->', $test);
     }
 
     /**
@@ -515,7 +515,7 @@ document.write(bar.strlen());');
             '/js/foo.js', 'text/javascript', array('conditional' => '!IE')
         );
         $test = $this->helper->toString();
-        $this->assertContains('<!--[if !IE]><!--><', $test);
-        $this->assertContains('<!--<![endif]-->', $test);
+        $this->assertStringContainsString('<!--[if !IE]><!--><', $test);
+        $this->assertStringContainsString('<!--<![endif]-->', $test);
     }
 }

--- a/tests/Zend/View/Helper/HeadStyleTest.php
+++ b/tests/Zend/View/Helper/HeadStyleTest.php
@@ -58,7 +58,7 @@ class Zend_View_Helper_HeadStyleTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $regKey = Zend_View_Helper_Placeholder_Registry::REGISTRY_KEY;
         if (Zend_Registry::isRegistered($regKey)) {
@@ -75,7 +75,7 @@ class Zend_View_Helper_HeadStyleTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -205,8 +205,8 @@ class Zend_View_Helper_HeadStyleTest extends \PHPUnit\Framework\TestCase
             'bogus' => 'unused'
         ));
         $value = $this->helper->toString();
-        $this->assertContains('<!--' . PHP_EOL, $value);
-        $this->assertContains(PHP_EOL . '-->', $value);
+        $this->assertStringContainsString('<!--' . PHP_EOL, $value);
+        $this->assertStringContainsString(PHP_EOL . '-->', $value);
     }
 
     public function testRenderedStyleTagsContainsDefaultMedia()
@@ -224,7 +224,7 @@ class Zend_View_Helper_HeadStyleTest extends \PHPUnit\Framework\TestCase
     {
         $this->helper->appendStyle('a { }', array('media' => 'screen, projection'));
         $string = $this->helper->toString();
-        $this->assertContains('media="screen,projection"', $string);
+        $this->assertStringContainsString('media="screen,projection"', $string);
     }
 
     public function testHeadStyleProxiesProperly()
@@ -261,9 +261,9 @@ class Zend_View_Helper_HeadStyleTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(3, $styles);
         $styles = substr_count($html, '</style>');
         $this->assertEquals(3, $styles);
-        $this->assertContains($style3, $html);
-        $this->assertContains($style2, $html);
-        $this->assertContains($style1, $html);
+        $this->assertStringContainsString($style3, $html);
+        $this->assertStringContainsString($style2, $html);
+        $this->assertStringContainsString($style1, $html);
     }
 
     public function testCapturingCapturesToObject()
@@ -274,7 +274,7 @@ class Zend_View_Helper_HeadStyleTest extends \PHPUnit\Framework\TestCase
         $values = $this->helper->getArrayCopy();
         $this->assertEquals(1, count($values));
         $item = array_shift($values);
-        $this->assertContains('foobar', $item->content);
+        $this->assertStringContainsString('foobar', $item->content);
     }
 
     public function testOverloadingOffsetSetWritesToSpecifiedIndex()
@@ -284,7 +284,7 @@ class Zend_View_Helper_HeadStyleTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, count($values));
         $this->assertTrue(isset($values[100]));
         $item = $values[100];
-        $this->assertContains('foobar', $item->content);
+        $this->assertStringContainsString('foobar', $item->content);
     }
 
     public function testInvalidMethodRaisesException()
@@ -318,12 +318,12 @@ h1 {
 
         $scripts = substr_count($string, '    <style');
         $this->assertEquals(2, $scripts);
-        $this->assertContains('    <!--', $string);
-        $this->assertContains('    a {', $string);
-        $this->assertContains('    h1 {', $string);
-        $this->assertContains('        display', $string);
-        $this->assertContains('        font-weight', $string);
-        $this->assertContains('    }', $string);
+        $this->assertStringContainsString('    <!--', $string);
+        $this->assertStringContainsString('    a {', $string);
+        $this->assertStringContainsString('    h1 {', $string);
+        $this->assertStringContainsString('        display', $string);
+        $this->assertStringContainsString('        font-weight', $string);
+        $this->assertStringContainsString('    }', $string);
     }
 
     public function testSerialCapturingWorks()
@@ -350,7 +350,7 @@ h1 {
                 $this->fail('Nested capturing should fail');
             } catch (Zend_View_Exception $e) {
                 $this->helper->headStyle()->captureEnd();
-                $this->assertContains('Cannot nest', $e->getMessage());
+                $this->assertStringContainsString('Cannot nest', $e->getMessage());
             }
     }
 
@@ -365,9 +365,9 @@ a {
 
         $scripts = substr_count($string, '    <style');
         $this->assertEquals(1, $scripts);
-        $this->assertContains('    <!--', $string);
-        $this->assertContains('    a {', $string);
-        $this->assertContains(' media="screen,projection"', $string);
+        $this->assertStringContainsString('    <!--', $string);
+        $this->assertStringContainsString('    a {', $string);
+        $this->assertStringContainsString(' media="screen,projection"', $string);
 
     }
 
@@ -382,9 +382,9 @@ a {
 
         $scripts = substr_count($string, '    <style');
         $this->assertEquals(1, $scripts);
-        $this->assertContains('    <!--', $string);
-        $this->assertContains('    a {', $string);
-        $this->assertContains(' media="screen,projection"', $string);
+        $this->assertStringContainsString('    <!--', $string);
+        $this->assertStringContainsString('    a {', $string);
+        $this->assertStringContainsString(' media="screen,projection"', $string);
 
     }
 
@@ -395,7 +395,7 @@ a {
     display: none;
 }', array('media' => 'screen,projection', 'conditional' => 'lt IE 7'));
         $test = $this->helper->toString();
-        $this->assertContains('<!--[if lt IE 7]>', $test);
+        $this->assertStringContainsString('<!--[if lt IE 7]>', $test);
     }
 
     /**
@@ -436,8 +436,8 @@ a {
         ));
         $value = $this->helper->toString();
 
-        $this->assertNotContains('<!--' . PHP_EOL, $value);
-        $this->assertNotContains(PHP_EOL . '-->', $value);
+        $this->assertStringNotContainsString('<!--' . PHP_EOL, $value);
+        $this->assertStringNotContainsString(PHP_EOL . '-->', $value);
     }
 
     /**
@@ -450,8 +450,8 @@ a {
     display: none;
 }', array('media' => 'screen,projection', 'conditional' => '!IE'));
         $test = $this->helper->toString();
-        $this->assertContains('<!--[if !IE]><!--><', $test);
-        $this->assertContains('<!--<![endif]-->', $test);
+        $this->assertStringContainsString('<!--[if !IE]><!--><', $test);
+        $this->assertStringContainsString('<!--<![endif]-->', $test);
     }
 
     /**
@@ -464,7 +464,7 @@ a {
     display: none;
 }', array('media' => 'screen,projection', 'conditional' => '! IE'));
         $test = $this->helper->toString();
-        $this->assertContains('<!--[if ! IE]><!--><', $test);
-        $this->assertContains('<!--<![endif]-->', $test);
+        $this->assertStringContainsString('<!--[if ! IE]><!--><', $test);
+        $this->assertStringContainsString('<!--<![endif]-->', $test);
     }
 }

--- a/tests/Zend/View/Helper/HeadTitleTest.php
+++ b/tests/Zend/View/Helper/HeadTitleTest.php
@@ -58,7 +58,7 @@ class Zend_View_Helper_HeadTitleTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $regKey = Zend_View_Helper_Placeholder_Registry::REGISTRY_KEY;
         if (Zend_Registry::isRegistered($regKey)) {
@@ -75,7 +75,7 @@ class Zend_View_Helper_HeadTitleTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -100,21 +100,21 @@ class Zend_View_Helper_HeadTitleTest extends \PHPUnit\Framework\TestCase
     public function testCanSetTitleViaHeadTitle()
     {
         $placeholder = $this->helper->headTitle('Foo Bar', 'SET');
-        $this->assertContains('Foo Bar', $placeholder->toString());
+        $this->assertStringContainsString('Foo Bar', $placeholder->toString());
     }
 
     public function testCanAppendTitleViaHeadTitle()
     {
         $placeholder = $this->helper->headTitle('Foo');
         $placeholder = $this->helper->headTitle('Bar');
-        $this->assertContains('FooBar', $placeholder->toString());
+        $this->assertStringContainsString('FooBar', $placeholder->toString());
     }
 
     public function testCanPrependTitleViaHeadTitle()
     {
         $placeholder = $this->helper->headTitle('Foo');
         $placeholder = $this->helper->headTitle('Bar', 'PREPEND');
-        $this->assertContains('BarFoo', $placeholder->toString());
+        $this->assertStringContainsString('BarFoo', $placeholder->toString());
     }
 
     public function testReturnedPlaceholderToStringContainsFullTitleElement()
@@ -128,8 +128,8 @@ class Zend_View_Helper_HeadTitleTest extends \PHPUnit\Framework\TestCase
     {
         $this->helper->headTitle('<script type="text/javascript">alert("foo");</script>');
         $string = $this->helper->toString();
-        $this->assertNotContains('<script', $string);
-        $this->assertNotContains('</script>', $string);
+        $this->assertStringNotContainsString('<script', $string);
+        $this->assertStringNotContainsString('</script>', $string);
     }
 
     public function testToStringEscapesSeparator()
@@ -138,10 +138,10 @@ class Zend_View_Helper_HeadTitleTest extends \PHPUnit\Framework\TestCase
                      ->headTitle('Bar')
                      ->setSeparator(' <br /> ');
         $string = $this->helper->toString();
-        $this->assertNotContains('<br />', $string);
-        $this->assertContains('Foo', $string);
-        $this->assertContains('Bar', $string);
-        $this->assertContains('br /', $string);
+        $this->assertStringNotContainsString('<br />', $string);
+        $this->assertStringContainsString('Foo', $string);
+        $this->assertStringContainsString('Bar', $string);
+        $this->assertStringContainsString('br /', $string);
     }
 
     public function testIndentationIsHonored()
@@ -150,7 +150,7 @@ class Zend_View_Helper_HeadTitleTest extends \PHPUnit\Framework\TestCase
         $this->helper->headTitle('foo');
         $string = $this->helper->toString();
 
-        $this->assertContains('    <title>', $string);
+        $this->assertStringContainsString('    <title>', $string);
     }
 
     public function testAutoEscapeIsHonored()
@@ -218,7 +218,7 @@ class Zend_View_Helper_HeadTitleTest extends \PHPUnit\Framework\TestCase
         $this->helper->setDefaultAttachOrder('PREPEND');
         $placeholder = $this->helper->headTitle('Foo');
         $placeholder = $this->helper->headTitle('Bar');
-        $this->assertContains('BarFoo', $placeholder->toString());
+        $this->assertStringContainsString('BarFoo', $placeholder->toString());
     }
 
     /**

--- a/tests/Zend/View/Helper/HtmlFlashTest.php
+++ b/tests/Zend/View/Helper/HtmlFlashTest.php
@@ -45,14 +45,14 @@ class Zend_View_Helper_HtmlFlashTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->helper = new Zend_View_Helper_HtmlFlash();
         $this->helper->setView($this->view);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -63,7 +63,7 @@ class Zend_View_Helper_HtmlFlashTest extends \PHPUnit\Framework\TestCase
 
         $objectStartElement = '<object data="/path/to/flash.swf" type="application/x-shockwave-flash">';
 
-        $this->assertContains($objectStartElement, $htmlFlash);
-        $this->assertContains('</object>', $htmlFlash);
+        $this->assertStringContainsString($objectStartElement, $htmlFlash);
+        $this->assertStringContainsString('</object>', $htmlFlash);
     }
 }

--- a/tests/Zend/View/Helper/HtmlListTest.php
+++ b/tests/Zend/View/Helper/HtmlListTest.php
@@ -45,14 +45,14 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->helper = new Zend_View_Helper_HtmlList();
         $this->helper->setView($this->view);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -63,10 +63,10 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
         $list = $this->helper->htmlList($items);
 
-        $this->assertContains('<ul>', $list);
-        $this->assertContains('</ul>', $list);
+        $this->assertStringContainsString('<ul>', $list);
+        $this->assertStringContainsString('</ul>', $list);
         foreach ($items as $item) {
-            $this->assertContains('<li>' . $item . '</li>', $list);
+            $this->assertStringContainsString('<li>' . $item . '</li>', $list);
         }
     }
 
@@ -76,10 +76,10 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
         $list = $this->helper->htmlList($items, true);
 
-        $this->assertContains('<ol>', $list);
-        $this->assertContains('</ol>', $list);
+        $this->assertStringContainsString('<ol>', $list);
+        $this->assertStringContainsString('</ol>', $list);
         foreach ($items as $item) {
-            $this->assertContains('<li>' . $item . '</li>', $list);
+            $this->assertStringContainsString('<li>' . $item . '</li>', $list);
         }
     }
 
@@ -90,12 +90,12 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
         $list = $this->helper->htmlList($items, false, $attribs);
 
-        $this->assertContains('<ul', $list);
-        $this->assertContains('class="selected"', $list);
-        $this->assertContains('name="list"', $list);
-        $this->assertContains('</ul>', $list);
+        $this->assertStringContainsString('<ul', $list);
+        $this->assertStringContainsString('class="selected"', $list);
+        $this->assertStringContainsString('name="list"', $list);
+        $this->assertStringContainsString('</ul>', $list);
         foreach ($items as $item) {
-            $this->assertContains('<li>' . $item . '</li>', $list);
+            $this->assertStringContainsString('<li>' . $item . '</li>', $list);
         }
     }
 
@@ -106,12 +106,12 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
         $list = $this->helper->htmlList($items, true, $attribs);
 
-        $this->assertContains('<ol', $list);
-        $this->assertContains('class="selected"', $list);
-        $this->assertContains('name="list"', $list);
-        $this->assertContains('</ol>', $list);
+        $this->assertStringContainsString('<ol', $list);
+        $this->assertStringContainsString('class="selected"', $list);
+        $this->assertStringContainsString('name="list"', $list);
+        $this->assertStringContainsString('</ol>', $list);
         foreach ($items as $item) {
-            $this->assertContains('<li>' . $item . '</li>', $list);
+            $this->assertStringContainsString('<li>' . $item . '</li>', $list);
         }
     }
 
@@ -124,10 +124,10 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
         $list = $this->helper->htmlList($items);
 
-        $this->assertContains('<ul>' . Zend_View_Helper_HtmlList::EOL, $list);
-        $this->assertContains('</ul>' . Zend_View_Helper_HtmlList::EOL, $list);
-        $this->assertContains('one<ul>' . Zend_View_Helper_HtmlList::EOL.'<li>four', $list);
-        $this->assertContains('<li>six</li>' . Zend_View_Helper_HtmlList::EOL . '</ul>' .
+        $this->assertStringContainsString('<ul>' . Zend_View_Helper_HtmlList::EOL, $list);
+        $this->assertStringContainsString('</ul>' . Zend_View_Helper_HtmlList::EOL, $list);
+        $this->assertStringContainsString('one<ul>' . Zend_View_Helper_HtmlList::EOL.'<li>four', $list);
+        $this->assertStringContainsString('<li>six</li>' . Zend_View_Helper_HtmlList::EOL . '</ul>' .
             Zend_View_Helper_HtmlList::EOL . '</li>' . Zend_View_Helper_HtmlList::EOL . '<li>two', $list);
     }
 
@@ -140,11 +140,11 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
         $list = $this->helper->htmlList($items);
 
-        $this->assertContains('<ul>' . Zend_View_Helper_HtmlList::EOL, $list);
-        $this->assertContains('</ul>' . Zend_View_Helper_HtmlList::EOL, $list);
-        $this->assertContains('one<ul>' . Zend_View_Helper_HtmlList::EOL . '<li>four', $list);
-        $this->assertContains('<li>four<ul>' . Zend_View_Helper_HtmlList::EOL . '<li>six', $list);
-        $this->assertContains('<li>five</li>' . Zend_View_Helper_HtmlList::EOL . '</ul>' .
+        $this->assertStringContainsString('<ul>' . Zend_View_Helper_HtmlList::EOL, $list);
+        $this->assertStringContainsString('</ul>' . Zend_View_Helper_HtmlList::EOL, $list);
+        $this->assertStringContainsString('one<ul>' . Zend_View_Helper_HtmlList::EOL . '<li>four', $list);
+        $this->assertStringContainsString('<li>four<ul>' . Zend_View_Helper_HtmlList::EOL . '<li>six', $list);
+        $this->assertStringContainsString('<li>five</li>' . Zend_View_Helper_HtmlList::EOL . '</ul>' .
             Zend_View_Helper_HtmlList::EOL . '</li>' . Zend_View_Helper_HtmlList::EOL . '<li>two', $list);
     }
 
@@ -154,12 +154,12 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
         $list = $this->helper->htmlList($items);
 
-        $this->assertContains('<ul>', $list);
-        $this->assertContains('</ul>', $list);
+        $this->assertStringContainsString('<ul>', $list);
+        $this->assertStringContainsString('</ul>', $list);
 
-        $this->assertContains('<li>one &lt;small&gt; test</li>', $list);
-        $this->assertContains('<li>second &amp; third</li>', $list);
-        $this->assertContains('<li>And \'some\' &quot;final&quot; test</li>', $list);
+        $this->assertStringContainsString('<li>one &lt;small&gt; test</li>', $list);
+        $this->assertStringContainsString('<li>second &amp; third</li>', $list);
+        $this->assertStringContainsString('<li>And \'some\' &quot;final&quot; test</li>', $list);
     }
 
     public function testListEscapeSwitchedOffForZF2283()
@@ -168,10 +168,10 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
         $list = $this->helper->htmlList($items, false, false, false);
 
-        $this->assertContains('<ul>', $list);
-        $this->assertContains('</ul>', $list);
+        $this->assertStringContainsString('<ul>', $list);
+        $this->assertStringContainsString('</ul>', $list);
 
-        $this->assertContains('<li>one <b>small</b> test</li>', $list);
+        $this->assertStringContainsString('<li>one <b>small</b> test</li>', $list);
     }
 
     /**
@@ -184,7 +184,7 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
         $list = $this->helper->htmlList($items, false, false, false);
 
         foreach ($items[1] as $item) {
-            $this->assertContains($item, $list);
+            $this->assertStringContainsString($item, $list);
         }
     }
 
@@ -224,8 +224,8 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
         $list = $this->helper->htmlList($items, false, false, false);
 
-        $this->assertContains('<ul>', $list);
-        $this->assertContains('</ul>', $list);
+        $this->assertStringContainsString('<ul>', $list);
+        $this->assertStringContainsString('</ul>', $list);
 
         $this->markTestSkipped('Wrong array_walk_recursive behavior.');
 
@@ -234,6 +234,6 @@ class Zend_View_Helper_HtmlListTest extends \PHPUnit\Framework\TestCase
 
     public function validateItems($value, $key, $userdata)
     {
-        $this->assertContains('<li>' . $value, $userdata);
+        $this->assertStringContainsString('<li>' . $value, $userdata);
     }
 }

--- a/tests/Zend/View/Helper/HtmlObjectTest.php
+++ b/tests/Zend/View/Helper/HtmlObjectTest.php
@@ -45,14 +45,14 @@ class Zend_View_Helper_HtmlObjectTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->helper = new Zend_View_Helper_HtmlObject();
         $this->helper->setView($this->view);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -66,8 +66,8 @@ class Zend_View_Helper_HtmlObjectTest extends \PHPUnit\Framework\TestCase
     {
         $htmlObject = $this->helper->htmlObject('datastring', 'typestring');
 
-        $this->assertContains('<object data="datastring" type="typestring">', $htmlObject);
-        $this->assertContains('</object>', $htmlObject);
+        $this->assertStringContainsString('<object data="datastring" type="typestring">', $htmlObject);
+        $this->assertStringContainsString('</object>', $htmlObject);
     }
 
     public function testMakeHtmlObjectWithAttribsWithoutParams()
@@ -77,8 +77,8 @@ class Zend_View_Helper_HtmlObjectTest extends \PHPUnit\Framework\TestCase
 
         $htmlObject = $this->helper->htmlObject('datastring', 'typestring', $attribs);
 
-        $this->assertContains('<object data="datastring" type="typestring" attribkey1="attribvalue1" attribkey2="attribvalue2">', $htmlObject);
-        $this->assertContains('</object>', $htmlObject);
+        $this->assertStringContainsString('<object data="datastring" type="typestring" attribkey1="attribvalue1" attribkey2="attribvalue2">', $htmlObject);
+        $this->assertStringContainsString('</object>', $htmlObject);
     }
 
     public function testMakeHtmlObjectWithoutAttribsWithParamsHtml()
@@ -90,13 +90,13 @@ class Zend_View_Helper_HtmlObjectTest extends \PHPUnit\Framework\TestCase
 
         $htmlObject = $this->helper->htmlObject('datastring', 'typestring', array(), $params);
 
-        $this->assertContains('<object data="datastring" type="typestring">', $htmlObject);
-        $this->assertContains('</object>', $htmlObject);
+        $this->assertStringContainsString('<object data="datastring" type="typestring">', $htmlObject);
+        $this->assertStringContainsString('</object>', $htmlObject);
 
         foreach ($params as $key => $value) {
             $param = '<param name="' . $key . '" value="' . $value . '">';
 
-            $this->assertContains($param, $htmlObject);
+            $this->assertStringContainsString($param, $htmlObject);
         }
     }
 
@@ -109,13 +109,13 @@ class Zend_View_Helper_HtmlObjectTest extends \PHPUnit\Framework\TestCase
 
         $htmlObject = $this->helper->htmlObject('datastring', 'typestring', array(), $params);
 
-        $this->assertContains('<object data="datastring" type="typestring">', $htmlObject);
-        $this->assertContains('</object>', $htmlObject);
+        $this->assertStringContainsString('<object data="datastring" type="typestring">', $htmlObject);
+        $this->assertStringContainsString('</object>', $htmlObject);
 
         foreach ($params as $key => $value) {
             $param = '<param name="' . $key . '" value="' . $value . '" />';
 
-            $this->assertContains($param, $htmlObject);
+            $this->assertStringContainsString($param, $htmlObject);
         }
     }
 
@@ -123,8 +123,8 @@ class Zend_View_Helper_HtmlObjectTest extends \PHPUnit\Framework\TestCase
     {
         $htmlObject = $this->helper->htmlObject('datastring', 'typestring', array(), array(), 'testcontent');
 
-        $this->assertContains('<object data="datastring" type="typestring">', $htmlObject);
-        $this->assertContains('testcontent', $htmlObject);
-        $this->assertContains('</object>', $htmlObject);
+        $this->assertStringContainsString('<object data="datastring" type="typestring">', $htmlObject);
+        $this->assertStringContainsString('testcontent', $htmlObject);
+        $this->assertStringContainsString('</object>', $htmlObject);
     }
 }

--- a/tests/Zend/View/Helper/HtmlPageTest.php
+++ b/tests/Zend/View/Helper/HtmlPageTest.php
@@ -45,14 +45,14 @@ class Zend_View_Helper_HtmlPageTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->helper = new Zend_View_Helper_HtmlPage();
         $this->helper->setView($this->view);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -65,7 +65,7 @@ class Zend_View_Helper_HtmlPageTest extends \PHPUnit\Framework\TestCase
                             . ' type="text/html"'
                             . ' classid="clsid:25336920-03F9-11CF-8FD0-00AA00686F13">';
 
-        $this->assertContains($objectStartElement, $htmlPage);
-        $this->assertContains('</object>', $htmlPage);
+        $this->assertStringContainsString($objectStartElement, $htmlPage);
+        $this->assertStringContainsString('</object>', $htmlPage);
     }
 }

--- a/tests/Zend/View/Helper/HtmlQuicktimeTest.php
+++ b/tests/Zend/View/Helper/HtmlQuicktimeTest.php
@@ -45,14 +45,14 @@ class Zend_View_Helper_HtmlQuicktimeTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->view = new Zend_View();
         $this->helper = new Zend_View_Helper_HtmlQuicktime();
         $this->helper->setView($this->view);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -66,7 +66,7 @@ class Zend_View_Helper_HtmlQuicktimeTest extends \PHPUnit\Framework\TestCase
                             . ' classid="clsid:02BF25D5-8C17-4B23-BC80-D3488ABDDC6B"'
                             . ' codebase="http://www.apple.com/qtactivex/qtplugin.cab">';
 
-        $this->assertContains($objectStartElement, $htmlQuicktime);
-        $this->assertContains('</object>', $htmlQuicktime);
+        $this->assertStringContainsString($objectStartElement, $htmlQuicktime);
+        $this->assertStringContainsString('</object>', $htmlQuicktime);
     }
 }

--- a/tests/Zend/View/Helper/InlineScriptTest.php
+++ b/tests/Zend/View/Helper/InlineScriptTest.php
@@ -58,7 +58,7 @@ class Zend_View_Helper_InlineScriptTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $regKey = Zend_View_Helper_Placeholder_Registry::REGISTRY_KEY;
         if (Zend_Registry::isRegistered($regKey)) {
@@ -75,7 +75,7 @@ class Zend_View_Helper_InlineScriptTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }

--- a/tests/Zend/View/Helper/JsonTest.php
+++ b/tests/Zend/View/Helper/JsonTest.php
@@ -45,7 +45,7 @@ class Zend_View_Helper_JsonTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         Zend_View_Helper_JsonTest_Layout::resetMvcInstance();
 
@@ -65,7 +65,7 @@ class Zend_View_Helper_JsonTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 

--- a/tests/Zend/View/Helper/LayoutTest.php
+++ b/tests/Zend/View/Helper/LayoutTest.php
@@ -44,7 +44,7 @@ class Zend_View_Helper_LayoutTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         Zend_Controller_Front::getInstance()->resetInstance();
         if (Zend_Controller_Action_HelperBroker::hasHelper('Layout')) {
@@ -63,7 +63,7 @@ class Zend_View_Helper_LayoutTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 

--- a/tests/Zend/View/Helper/Navigation/LinksTest.php
+++ b/tests/Zend/View/Helper/Navigation/LinksTest.php
@@ -54,7 +54,7 @@ class Zend_View_Helper_Navigation_LinksTest
     private $_doctypeHelper;
     private $_oldDoctype;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -70,7 +70,7 @@ class Zend_View_Helper_Navigation_LinksTest
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->_doctypeHelper->setDoctype($this->_oldDoctype);
     }
@@ -530,7 +530,7 @@ class Zend_View_Helper_Navigation_LinksTest
             $this->fail('An invalid value was given, but a ' .
                         'Zend_View_Exception was not thrown');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('Invalid argument: $rel', $e->getMessage());
+            $this->assertStringContainsString('Invalid argument: $rel', $e->getMessage());
         }
     }
 
@@ -542,7 +542,7 @@ class Zend_View_Helper_Navigation_LinksTest
             $this->fail('An invalid value was given, but a ' .
                         'Zend_View_Exception was not thrown');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('Invalid relation attribute', $e->getMessage());
+            $this->assertStringContainsString('Invalid relation attribute', $e->getMessage());
         }
     }
 

--- a/tests/Zend/View/Helper/Navigation/MenuTest.php
+++ b/tests/Zend/View/Helper/Navigation/MenuTest.php
@@ -662,7 +662,7 @@ class Zend_View_Helper_Navigation_MenuTest
     {
         $this->_helper->setUlId('foo');
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<ul class="navigation" id="foo">',
             $this->_helper->renderMenu()
         );
@@ -673,7 +673,7 @@ class Zend_View_Helper_Navigation_MenuTest
      */
     public function testRenderingWithUlIdPerOptions()
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<ul class="navigation" id="foo">',
             $this->_helper->renderMenu(null, array('ulId' => 'foo'))
         );
@@ -688,7 +688,7 @@ class Zend_View_Helper_Navigation_MenuTest
                       ->setOnlyActiveBranch()
                       ->setRenderParents();
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<ul class="navigation" id="foo">',
             $this->_helper->renderMenu()
         );
@@ -699,7 +699,7 @@ class Zend_View_Helper_Navigation_MenuTest
      */
     public function testRenderingSubMenuWithUlId()
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<ul class="navigation" id="foo">',
             $this->_helper->renderSubMenu(null, null, null, 'foo')
         );
@@ -710,7 +710,7 @@ class Zend_View_Helper_Navigation_MenuTest
      */
     public function testRenderingDeepestMenuWithUlId()
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<ul class="navigation" id="foo">',
             $this->_helper->renderMenu(null, array('ulId' => 'foo'))
         );
@@ -737,11 +737,11 @@ class Zend_View_Helper_Navigation_MenuTest
         $container->findBy('href', 'page1')->setClass('foo');
 
         // Tests
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li class="foo">',
             $this->_helper->renderMenu()
         );
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             '<a class="foo" href="page1">Page 1</a>',
             $this->_helper->renderMenu()
         );
@@ -763,11 +763,11 @@ class Zend_View_Helper_Navigation_MenuTest
             'addPageClassToLi' => true,
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li class="active foo">',
             $this->_helper->renderMenu(null, $options)
         );
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             '<a class="foo" href="page1">Page 1</a>',
             $this->_helper->renderMenu(null, $options)
         );
@@ -802,8 +802,8 @@ class Zend_View_Helper_Navigation_MenuTest
 
         $html = $this->_helper->renderMenu(null, $options);
 
-        $this->assertContains('<li class="current">', $html);
-        $this->assertNotContains('<li class="active">', $html);
+        $this->assertStringContainsString('<li class="current">', $html);
+        $this->assertStringNotContainsString('<li class="active">', $html);
     }
 
     /**

--- a/tests/Zend/View/Helper/Navigation/NavigationTest.php
+++ b/tests/Zend/View/Helper/Navigation/NavigationTest.php
@@ -266,7 +266,7 @@ class Zend_View_Helper_Navigation_NavigationTest
             $this->fail('An invalid argument was given, but a ' .
                         'Zend_View_Exception was not thrown');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('$role must be a string', $e->getMessage());
+            $this->assertStringContainsString('$role must be a string', $e->getMessage());
         }
     }
 
@@ -277,7 +277,7 @@ class Zend_View_Helper_Navigation_NavigationTest
             $this->fail('An invalid argument was given, but a ' .
                         'Zend_View_Exception was not thrown');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('$role must be a string', $e->getMessage());
+            $this->assertStringContainsString('$role must be a string', $e->getMessage());
         }
     }
 
@@ -318,7 +318,7 @@ class Zend_View_Helper_Navigation_NavigationTest
             $this->fail('An invalid argument was given, but a ' .
                         'Zend_View_Exception was not thrown');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('$role must be', $e->getMessage());
+            $this->assertStringContainsString('$role must be', $e->getMessage());
         }
     }
 
@@ -329,7 +329,7 @@ class Zend_View_Helper_Navigation_NavigationTest
             $this->fail('An invalid argument was given, but a ' .
                         'Zend_View_Exception was not thrown');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('$role must be', $e->getMessage());
+            $this->assertStringContainsString('$role must be', $e->getMessage());
         }
     }
 
@@ -346,7 +346,7 @@ class Zend_View_Helper_Navigation_NavigationTest
         $this->_helper->__toString();
         restore_error_handler();
 
-        $this->assertContains('array must contain two values', $this->_errorMessage);
+        $this->assertStringContainsString('array must contain two values', $this->_errorMessage);
     }
 
     public function testPageIdShouldBeNormalized()

--- a/tests/Zend/View/Helper/Navigation/SitemapTest.php
+++ b/tests/Zend/View/Helper/Navigation/SitemapTest.php
@@ -58,7 +58,7 @@ class Zend_View_Helper_Navigation_SitemapTest
      */
     protected $_helper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         date_default_timezone_set('Europe/Berlin');
 
@@ -91,7 +91,7 @@ class Zend_View_Helper_Navigation_SitemapTest
         $this->_helper->setFormatOutput(true);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (null !== $this->_oldRequest) {
             $this->_front->setRequest($this->_oldRequest);
@@ -250,7 +250,7 @@ class Zend_View_Helper_Navigation_SitemapTest
             $this->fail('An invalid server URL was given, but a ' .
                         'Zend_Uri_Exception was not thrown');
         } catch (Zend_Uri_Exception $e) {
-            $this->assertContains('Illegal scheme', $e->getMessage());
+            $this->assertStringContainsString('Illegal scheme', $e->getMessage());
         }
     }
 

--- a/tests/Zend/View/Helper/Navigation/TestAbstract.php
+++ b/tests/Zend/View/Helper/Navigation/TestAbstract.php
@@ -94,7 +94,7 @@ abstract class Zend_View_Helper_Navigation_TestAbstract
      * Prepares the environment before running a test
      *
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $cwd = dirname(__FILE__);
 
@@ -128,7 +128,7 @@ abstract class Zend_View_Helper_Navigation_TestAbstract
      * Cleans up the environment after running a test
      *
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $front = Zend_Controller_Front::getInstance();
 

--- a/tests/Zend/View/Helper/PartialLoopTest.php
+++ b/tests/Zend/View/Helper/PartialLoopTest.php
@@ -58,7 +58,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->basePath = dirname(__FILE__) . '/_files/modules';
         $this->helper = new Zend_View_Helper_PartialLoop();
@@ -71,7 +71,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -96,7 +96,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoop.phtml', $data);
         foreach ($data as $item) {
             $string = 'This is an iteration: ' . $item['message'];
-            $this->assertContains($string, $result);
+            $this->assertStringContainsString($string, $result);
         }
     }
 
@@ -121,7 +121,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoop.phtml', $o);
         foreach ($data as $item) {
             $string = 'This is an iteration: ' . $item['message'];
-            $this->assertContains($string, $result);
+            $this->assertStringContainsString($string, $result);
         }
     }
 
@@ -146,7 +146,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoop.phtml', $rIterator);
         foreach ($rIterator as $item) {
             foreach ($item as $key => $value) {
-                $this->assertContains($value, $result, var_export($value, 1));
+                $this->assertStringContainsString($value, $result, var_export($value, 1));
             }
         }
     }
@@ -197,7 +197,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoop.phtml', 'foo', $data);
         foreach ($data as $item) {
             $string = 'This is an iteration in the foo module: ' . $item['message'];
-            $this->assertContains($string, $result);
+            $this->assertStringContainsString($string, $result);
         }
     }
 
@@ -225,7 +225,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoop.phtml', $o);
         foreach ($data as $item) {
             $string = 'This is an iteration: ' . $item['message'];
-            $this->assertContains($string, $result);
+            $this->assertStringContainsString($string, $result);
         }
     }
 
@@ -247,7 +247,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoop.phtml', $o);
         foreach ($data as $item) {
             $string = 'This is an iteration: ' . $item['message'];
-            $this->assertContains($string, $result, $result);
+            $this->assertStringContainsString($string, $result, $result);
         }
     }
 
@@ -274,7 +274,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoopObject.phtml', $o);
         foreach ($data as $item) {
             $string = 'This is an iteration: ' . $item->message;
-            $this->assertContains($string, $result, $result);
+            $this->assertStringContainsString($string, $result, $result);
         }
     }
 
@@ -322,7 +322,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoopCouter.phtml', $data);
         foreach ($data as $key=>$item) {
             $string = 'This is an iteration: ' . $item['message'] . ', pointer at ' . ($key+1);
-            $this->assertContains($string, $result);
+            $this->assertStringContainsString($string, $result);
         }
     }
 
@@ -347,13 +347,13 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoopCouter.phtml', $data);
         foreach ($data as $key=>$item) {
             $string = 'This is an iteration: ' . $item['message'] . ', pointer at ' . ($key+1);
-            $this->assertContains($string, $result);
+            $this->assertStringContainsString($string, $result);
         }
 
         $result = $this->helper->partialLoop('partialLoopCouter.phtml', $data);
         foreach ($data as $key=>$item) {
             $string = 'This is an iteration: ' . $item['message'] . ', pointer at ' . ($key+1);
-            $this->assertContains($string, $result);
+            $this->assertStringContainsString($string, $result);
         }
     }
 
@@ -380,7 +380,7 @@ class Zend_View_Helper_PartialLoopTest extends \PHPUnit\Framework\TestCase
         $result = $this->helper->partialLoop('partialLoopCouter.phtml', $data);
         foreach ($data as $key => $item) {
             $string = 'Total count: ' . count($data);
-            $this->assertContains($string, $result);
+            $this->assertStringContainsString($string, $result);
         }
     }
 }

--- a/tests/Zend/View/Helper/PartialTest.php
+++ b/tests/Zend/View/Helper/PartialTest.php
@@ -58,7 +58,7 @@ class Zend_View_Helper_PartialTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->basePath = dirname(__FILE__) . '/_files/modules';
         $this->helper = new Zend_View_Helper_Partial();
@@ -71,7 +71,7 @@ class Zend_View_Helper_PartialTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -86,7 +86,7 @@ class Zend_View_Helper_PartialTest extends \PHPUnit\Framework\TestCase
         ));
         $this->helper->setView($view);
         $return = $this->helper->partial('partialOne.phtml');
-        $this->assertContains('This is the first test partial', $return);
+        $this->assertStringContainsString('This is the first test partial', $return);
     }
 
     /**
@@ -100,8 +100,8 @@ class Zend_View_Helper_PartialTest extends \PHPUnit\Framework\TestCase
         $view->message = 'This should never be read';
         $this->helper->setView($view);
         $return = $this->helper->partial('partialThree.phtml', array('message' => 'This message should be read'));
-        $this->assertNotContains($view->message, $return);
-        $this->assertContains('This message should be read', $return, $return);
+        $this->assertStringNotContainsString($view->message, $return);
+        $this->assertStringContainsString('This message should be read', $return, $return);
     }
 
     /**
@@ -115,7 +115,7 @@ class Zend_View_Helper_PartialTest extends \PHPUnit\Framework\TestCase
         ));
         $this->helper->setView($view);
         $return = $this->helper->partial('partialTwo.phtml', 'foo');
-        $this->assertContains('This is the second partial', $return, $return);
+        $this->assertStringContainsString('This is the second partial', $return, $return);
     }
 
     /**
@@ -188,7 +188,7 @@ class Zend_View_Helper_PartialTest extends \PHPUnit\Framework\TestCase
 
         foreach (get_object_vars($model) as $key => $value) {
             $string = sprintf('%s: %s', $key, $value);
-            $this->assertContains($string, $return);
+            $this->assertStringContainsString($string, $return);
         }
     }
 
@@ -204,7 +204,7 @@ class Zend_View_Helper_PartialTest extends \PHPUnit\Framework\TestCase
 
         foreach ($model->toArray() as $key => $value) {
             $string = sprintf('%s: %s', $key, $value);
-            $this->assertContains($string, $return);
+            $this->assertStringContainsString($string, $return);
         }
     }
 
@@ -221,11 +221,11 @@ class Zend_View_Helper_PartialTest extends \PHPUnit\Framework\TestCase
         $this->helper->setView($view);
         $return = $this->helper->partial('partialObj.phtml', $model);
 
-        $this->assertNotContains('No object model passed', $return);
+        $this->assertStringNotContainsString('No object model passed', $return);
 
         foreach (get_object_vars($model) as $key => $value) {
             $string = sprintf('%s: %s', $key, $value);
-            $this->assertContains($string, $return, "Checking for '$return' containing '$string'");
+            $this->assertStringContainsString($string, $return, "Checking for '$return' containing '$string'");
         }
     }
 

--- a/tests/Zend/View/Helper/Placeholder/ContainerTest.php
+++ b/tests/Zend/View/Helper/Placeholder/ContainerTest.php
@@ -47,7 +47,7 @@ class Zend_View_Helper_Placeholder_ContainerTest extends \PHPUnit\Framework\Test
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = new Zend_View_Helper_Placeholder_Container(array());
     }
@@ -58,7 +58,7 @@ class Zend_View_Helper_Placeholder_ContainerTest extends \PHPUnit\Framework\Test
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->container);
     }
@@ -187,7 +187,7 @@ class Zend_View_Helper_Placeholder_ContainerTest extends \PHPUnit\Framework\Test
         $this->container->captureEnd();
 
         $value = $this->container->getValue();
-        $this->assertContains('This is content intended for capture', $value);
+        $this->assertStringContainsString('This is content intended for capture', $value);
     }
 
     /**
@@ -208,7 +208,7 @@ class Zend_View_Helper_Placeholder_ContainerTest extends \PHPUnit\Framework\Test
         $keys      = array_keys($value);
         $lastIndex = array_pop($keys);
         $this->assertEquals('foo', $value[$lastIndex - 1]);
-        $this->assertContains('This is content intended for capture', $value[$lastIndex]);
+        $this->assertStringContainsString('This is content intended for capture', $value[$lastIndex]);
     }
 
     /**
@@ -229,7 +229,7 @@ class Zend_View_Helper_Placeholder_ContainerTest extends \PHPUnit\Framework\Test
         $keys      = array_keys($value);
         $lastIndex = array_pop($keys);
         $this->assertEquals('foo', $value[$lastIndex]);
-        $this->assertContains('This is content intended for capture', $value[$lastIndex - 1]);
+        $this->assertStringContainsString('This is content intended for capture', $value[$lastIndex - 1]);
     }
 
     /**
@@ -245,7 +245,7 @@ class Zend_View_Helper_Placeholder_ContainerTest extends \PHPUnit\Framework\Test
         $this->assertEquals(1, count($this->container));
 
         $value = $this->container->getValue();
-        $this->assertContains('This is content intended for capture', $value);
+        $this->assertStringContainsString('This is content intended for capture', $value);
     }
 
     /**
@@ -260,7 +260,7 @@ class Zend_View_Helper_Placeholder_ContainerTest extends \PHPUnit\Framework\Test
         $this->assertEquals(1, count($this->container));
         $this->assertTrue(isset($this->container['key']));
         $value = $this->container['key'];
-        $this->assertContains('This is content intended for capture', $value);
+        $this->assertStringContainsString('This is content intended for capture', $value);
     }
 
     /**
@@ -276,7 +276,7 @@ class Zend_View_Helper_Placeholder_ContainerTest extends \PHPUnit\Framework\Test
         $this->assertEquals(1, count($this->container));
         $this->assertTrue(isset($this->container['key']));
         $value = $this->container['key'];
-        $this->assertContains('This is content intended for capture', $value);
+        $this->assertStringContainsString('This is content intended for capture', $value);
     }
 
     /**
@@ -292,7 +292,7 @@ class Zend_View_Helper_Placeholder_ContainerTest extends \PHPUnit\Framework\Test
         $this->assertEquals(1, count($this->container));
         $this->assertTrue(isset($this->container['key']));
         $value = $this->container['key'];
-        $this->assertContains('Foobar This is content intended for capture', $value);
+        $this->assertStringContainsString('Foobar This is content intended for capture', $value);
     }
 
     /**

--- a/tests/Zend/View/Helper/Placeholder/RegistryTest.php
+++ b/tests/Zend/View/Helper/Placeholder/RegistryTest.php
@@ -47,7 +47,7 @@ class Zend_View_Helper_Placeholder_RegistryTest extends \PHPUnit\Framework\TestC
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $registry = Zend_Registry::getInstance();
         if (isset($registry[Zend_View_Helper_Placeholder_Registry::REGISTRY_KEY])) {
@@ -62,7 +62,7 @@ class Zend_View_Helper_Placeholder_RegistryTest extends \PHPUnit\Framework\TestC
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->registry);
     }

--- a/tests/Zend/View/Helper/Placeholder/StandaloneContainerTest.php
+++ b/tests/Zend/View/Helper/Placeholder/StandaloneContainerTest.php
@@ -51,7 +51,7 @@ class Zend_View_Helper_Placeholder_StandaloneContainerTest extends \PHPUnit\Fram
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $regKey = Zend_View_Helper_Placeholder_Registry::REGISTRY_KEY;
         if (Zend_Registry::isRegistered($regKey)) {
@@ -68,7 +68,7 @@ class Zend_View_Helper_Placeholder_StandaloneContainerTest extends \PHPUnit\Fram
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
     }
@@ -90,9 +90,9 @@ class Zend_View_Helper_Placeholder_StandaloneContainerTest extends \PHPUnit\Fram
         $foo2->append('Bar');
 
         $test = $foo1->toString();
-        $this->assertContains('Foo', $test);
-        $this->assertContains(' - ', $test);
-        $this->assertContains('Bar', $test);
+        $this->assertStringContainsString('Foo', $test);
+        $this->assertStringContainsString(' - ', $test);
+        $this->assertStringContainsString('Bar', $test);
     }
 }
 

--- a/tests/Zend/View/Helper/PlaceholderTest.php
+++ b/tests/Zend/View/Helper/PlaceholderTest.php
@@ -53,7 +53,7 @@ class Zend_View_Helper_PlaceholderTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->placeholder = new Zend_View_Helper_Placeholder();
     }
@@ -64,7 +64,7 @@ class Zend_View_Helper_PlaceholderTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->placeholder);
         Zend_Registry::getInstance()->offsetUnset(Zend_View_Helper_Placeholder_Registry::REGISTRY_KEY);

--- a/tests/Zend/View/Helper/RenderToPlaceholderTest.php
+++ b/tests/Zend/View/Helper/RenderToPlaceholderTest.php
@@ -38,7 +38,7 @@ class Zend_View_Helper_RenderToPlaceholderTest extends \PHPUnit\Framework\TestCa
 
     protected $_view = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_view = new Zend_View(array('scriptPath'=>dirname(__FILE__).'/_files/scripts/'));
     }

--- a/tests/Zend/View/Helper/ServerUrlTest.php
+++ b/tests/Zend/View/Helper/ServerUrlTest.php
@@ -46,7 +46,7 @@ class Zend_View_Helper_ServerUrlTest extends \PHPUnit\Framework\TestCase
     /**
      * Prepares the environment before running a test.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->_serverBackup = $_SERVER;
         unset($_SERVER['HTTPS']);
@@ -55,7 +55,7 @@ class Zend_View_Helper_ServerUrlTest extends \PHPUnit\Framework\TestCase
     /**
      * Cleans up the environment after running a test.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $_SERVER = $this->_serverBackup;
     }

--- a/tests/Zend/View/Helper/TranslateTest.php
+++ b/tests/Zend/View/Helper/TranslateTest.php
@@ -68,7 +68,7 @@ class Zend_View_Helper_TranslateTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->clearRegistry();
         $this->helper = new Zend_View_Helper_Translate();
@@ -80,7 +80,7 @@ class Zend_View_Helper_TranslateTest extends \PHPUnit\Framework\TestCase
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->helper);
         $this->clearRegistry();
@@ -122,7 +122,7 @@ class Zend_View_Helper_TranslateTest extends \PHPUnit\Framework\TestCase
         try {
             $helper = new Zend_View_Helper_Translate('something');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('must set an instance of Zend_Translate', $e->getMessage());
+            $this->assertStringContainsString('must set an instance of Zend_Translate', $e->getMessage());
         }
     }
 
@@ -131,7 +131,7 @@ class Zend_View_Helper_TranslateTest extends \PHPUnit\Framework\TestCase
         try {
             $this->helper->setTranslator('something');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('must set an instance of Zend_Translate', $e->getMessage());
+            $this->assertStringContainsString('must set an instance of Zend_Translate', $e->getMessage());
         }
     }
 
@@ -140,7 +140,7 @@ class Zend_View_Helper_TranslateTest extends \PHPUnit\Framework\TestCase
         try {
             $this->helper->getLocale();
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('must set an instance of Zend_Translate', $e->getMessage());
+            $this->assertStringContainsString('must set an instance of Zend_Translate', $e->getMessage());
         }
     }
 
@@ -149,7 +149,7 @@ class Zend_View_Helper_TranslateTest extends \PHPUnit\Framework\TestCase
         try {
             $this->helper->setLocale('de');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('must set an instance of Zend_Translate', $e->getMessage());
+            $this->assertStringContainsString('must set an instance of Zend_Translate', $e->getMessage());
         }
     }
 

--- a/tests/Zend/View/Helper/UrlTest.php
+++ b/tests/Zend/View/Helper/UrlTest.php
@@ -49,7 +49,7 @@ class Zend_View_Helper_UrlTest extends \PHPUnit\Framework\TestCase
      *
      * @access protected
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->front = Zend_Controller_Front::getInstance();
         $this->front->getRouter()->addDefaultRoutes();

--- a/tests/Zend/ViewTest.php
+++ b/tests/Zend/ViewTest.php
@@ -46,14 +46,14 @@ require_once 'Zend/Loader.php';
 class Zend_ViewTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->notices = array();
         $this->errorReporting = error_reporting();
         $this->displayErrors  = ini_get('display_errors');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         error_reporting($this->errorReporting);
         ini_set('display_errors', $this->displayErrors);
@@ -254,7 +254,7 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
             $view->nonexistantHelper();
             // @todo  fail if no exception?
         } catch (Zend_Exception $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
     }
 
@@ -274,7 +274,7 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
             $view->stubEmpty();
             // @todo  fail if no exception?
         } catch (Zend_Exception $e) {
-            $this->assertContains("not found", $e->getMessage());
+            $this->assertStringContainsString("not found", $e->getMessage());
         }
     }
 
@@ -318,8 +318,8 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue(file_exists($logFile));
         $log = file_get_contents($logFile);
         unlink($logFile); // clean up...
-        $this->assertContains('This text should not be displayed', $log);
-        $this->assertNotContains('testSubTemplate.phtml', $log);
+        $this->assertStringContainsString('This text should not be displayed', $log);
+        $this->assertStringNotContainsString('testSubTemplate.phtml', $log);
     }
 
     /**
@@ -573,7 +573,7 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($view, $status);
         $helperPaths = $view->getHelperPaths();
         $this->assertTrue(array_key_exists('My_View_Helper_', $helperPaths));
-        $this->assertContains($this->_filterPath('Zend/View/_stubs/HelperDir1/'), $this->_filterPath(current($helperPaths['My_View_Helper_'])));
+        $this->assertStringContainsString($this->_filterPath('Zend/View/_stubs/HelperDir1/'), $this->_filterPath(current($helperPaths['My_View_Helper_'])));
     }
 
     public function testFilterPathWithPrefix()
@@ -851,7 +851,7 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
         $view = new Zend_View();
         $view->declareVars();
         $helperPath = $view->getHelperPath('declareVars');
-        $this->assertContains($expected, $helperPath);
+        $this->assertStringContainsString($expected, $helperPath);
     }
 
     public function testGetFilter()
@@ -904,7 +904,7 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
             $view->render('bazbatNotExists.php.tpl');
             $this->fail('Non-existent view script should cause an exception');
         } catch (Exception $e) {
-            $this->assertContains($base. '_templates', $e->getMessage());
+            $this->assertStringContainsString($base. '_templates', $e->getMessage());
         }
     }
 
@@ -912,13 +912,13 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
     {
         $view = new Zend_View();
         $hidden = $view->formHidden('foo', 'bar');
-        $this->assertContains('<input type="hidden"', $hidden);
+        $this->assertStringContainsString('<input type="hidden"', $hidden);
 
         $hidden = $view->getHelper('formHidden')->formHidden('foo', 'bar');
-        $this->assertContains('<input type="hidden"', $hidden);
+        $this->assertStringContainsString('<input type="hidden"', $hidden);
 
         $hidden = $view->getHelper('FormHidden')->formHidden('foo', 'bar');
-        $this->assertContains('<input type="hidden"', $hidden);
+        $this->assertStringContainsString('<input type="hidden"', $hidden);
     }
 
     public function testGetHelperUsingDifferentCasesReturnsSameInstance()
@@ -942,21 +942,21 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
             $view->setHelperPath(dirname(__FILE__) . '/View/_stubs/HelperDir1', null);
             $this->fail('Exception for empty prefix was expected.');
         } catch (Exception $e) {
-            $this->assertContains('only takes strings', $e->getMessage());
+            $this->assertStringContainsString('only takes strings', $e->getMessage());
         }
 
         try {
             $view->setHelperPath(dirname(__FILE__) . '/View/_stubs/HelperDir1', null);
             $this->fail('Exception for empty prefix was expected.');
         } catch (Exception $e) {
-            $this->assertContains('only takes strings', $e->getMessage());
+            $this->assertStringContainsString('only takes strings', $e->getMessage());
         }
 
 
         try {
             $helper = $view->getHelper('Datetime');
         } catch (Exception $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
     }
 
@@ -985,21 +985,21 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
             $view->render('../foobar.html');
             $this->fail('Should not allow parent directory traversal');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('parent directory traversal', $e->getMessage());
+            $this->assertStringContainsString('parent directory traversal', $e->getMessage());
         }
 
         try {
             $view->render('foo/../foobar.html');
             $this->fail('Should not allow parent directory traversal');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('parent directory traversal', $e->getMessage());
+            $this->assertStringContainsString('parent directory traversal', $e->getMessage());
         }
 
         try {
             $view->render('foo/..\foobar.html');
             $this->fail('Should not allow parent directory traversal');
         } catch (Zend_View_Exception $e) {
-            $this->assertContains('parent directory traversal', $e->getMessage());
+            $this->assertStringContainsString('parent directory traversal', $e->getMessage());
         }
     }
 
@@ -1042,7 +1042,7 @@ class Zend_ViewTest extends \PHPUnit\Framework\TestCase
         ));
         try {
             $test = $view->render('../_stubs/scripts/LfiProtectionCheck.phtml');
-            $this->assertContains('LFI', $test);
+            $this->assertStringContainsString('LFI', $test);
         } catch (Zend_View_Exception $e) {
             $this->fail('LFI attack failed: ' . $e->getMessage());
         }

--- a/tests/resources/languages/Zend_ValidateTest.php
+++ b/tests/resources/languages/Zend_ValidateTest.php
@@ -40,7 +40,7 @@ class resources_languages_Zend_ValidateTest extends \PHPUnit\Framework\TestCase
     protected $_languages    = array();
     protected $_translations = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_langDir = dirname(dirname(dirname(dirname(__FILE__))))
                         . DIRECTORY_SEPARATOR . 'resources' . DIRECTORY_SEPARATOR . 'languages';


### PR DESCRIPTION
- PHP 7.3-7.4 is now required
- PHPUnit is upgraded to 9 version
